### PR TITLE
Add a PANGEO_SCRATCH variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ docker run -it --rm -p 8888:8888 pangeo/base-notebook:latest jupyter lab --ip 0.
 Everything stems from the `Dockerfile` in the `base-image` folder. The `base-image` configures default settings for Conda and Dask with `condarc.yml` and `dask_config.yml` files. The `base-image` is not meant to run on its own, it is the common foundation for `-notebook` images that install Python packages including JupyerLab and lab extensions. Lists of Conda packages for each image are specified in an `environment.yml` in each `-notebook` folder, and compatible Dask and Jupyter packages are guaranteed by specifying the `pangeo-notebook` [conda metapackage](https://github.com/conda-forge/pangeo-notebook-feedstock).
 
 You can pre-solve for compatible environments locally with [conda-lock](https://github.com/mariusvniekerk/conda-lock/blob/master/README.md) to convert the `environment.yml` file to a [conda-linux-64.lock](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#building-identical-conda-environments) file which is an explicit list of compatible packages solved by Conda. The major advantage of doing this is that if you rebuild at a later date the resulting Conda environment is identical, which improves reproducibility. For this reason, when building off of the `base-image`, any existing `conda-linux-64.lock` file takes precedence over the `environment.yml` file.
+
+### Environment
+
+The runtime environment sets two variables by default
+
+1. `$PANGEO_ENV`: name of the conda environemnt.
+2. `$PANGEO_SCRATCH`: a URL like `gcs://pangeo-scratch/username/` that
+   points to a cloud storage bucket for temporary storage. This is set
+   if the variable `$PANGEO_SCRATCH_PROTOCOL` and `JUPYTERHUB_USERNAME`
+   are detected.

--- a/README.md
+++ b/README.md
@@ -77,5 +77,5 @@ The runtime environment sets two variables by default
 1. `$PANGEO_ENV`: name of the conda environemnt.
 2. `$PANGEO_SCRATCH`: a URL like `gcs://pangeo-scratch/username/` that
    points to a cloud storage bucket for temporary storage. This is set
-   if the variable `$PANGEO_SCRATCH_PROTOCOL` and `JUPYTERHUB_USERNAME`
-   are detected.
+   if the variable `$PANGEO_SCRATCH_PREFIX` and `JUPYTERHUB_USERNAME`
+   are detected. The prefix should be like `s3://pangeo-scratch`

--- a/base-image/start
+++ b/base-image/start
@@ -3,6 +3,11 @@
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 
 export PANGEO_ENV="base"
+if [[ -z "${PANGEO_SCRATCH_PROTOCOL}" ]]; then
+    :
+else
+    export PANGEO_SCRATCH="${PANGEO_SCRATCH_PROTOCOL}://pangeo-scratch/${JUPYTERHUB_USERNAME}/"
+fi
 
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 

--- a/base-image/start
+++ b/base-image/start
@@ -3,10 +3,8 @@
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 
 export PANGEO_ENV="base"
-if [[ -z "${PANGEO_SCRATCH_PROTOCOL}" ]]; then
-    :
-else
-    export PANGEO_SCRATCH="${PANGEO_SCRATCH_PROTOCOL}://pangeo-scratch/${JUPYTERHUB_USERNAME}/"
+if ! [[ -z "${PANGEO_SCRATCH_PREFIX}" ]] && ! [[ -z "${JUPYTERHUB_USERNAME}" ]]; then
+    export PANGEO_SCRATCH="${PANGEO_SCRATCH_PREFIX}/${JUPYTERHUB_USERNAME}/"
 fi
 
 # ==== ONLY EDIT WITHIN THIS BLOCK =====

--- a/base-notebook/start
+++ b/base-notebook/start
@@ -3,6 +3,11 @@
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 
 export PANGEO_ENV="base-notebook"
+if [[ -z "${PANGEO_SCRATCH_PROTOCOL}" ]]; then
+    :
+else
+    export PANGEO_SCRATCH="${PANGEO_SCRATCH_PROTOCOL}://pangeo-scratch/${JUPYTERHUB_USERNAME}/"
+fi
 
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 

--- a/base-notebook/start
+++ b/base-notebook/start
@@ -3,10 +3,8 @@
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 
 export PANGEO_ENV="base-notebook"
-if [[ -z "${PANGEO_SCRATCH_PROTOCOL}" ]]; then
-    :
-else
-    export PANGEO_SCRATCH="${PANGEO_SCRATCH_PROTOCOL}://pangeo-scratch/${JUPYTERHUB_USERNAME}/"
+if ! [[ -z "${PANGEO_SCRATCH_PREFIX}" ]] && ! [[ -z "${JUPYTERHUB_USERNAME}" ]]; then
+    export PANGEO_SCRATCH="${PANGEO_SCRATCH_PREFIX}/${JUPYTERHUB_USERNAME}/"
 fi
 
 # ==== ONLY EDIT WITHIN THIS BLOCK =====

--- a/ml-notebook/start
+++ b/ml-notebook/start
@@ -3,10 +3,8 @@
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 
 export PANGEO_ENV="ml-notebook"
-if [[ -z "${PANGEO_SCRATCH_PROTOCOL}" ]]; then
-    :
-else
-    export PANGEO_SCRATCH="${PANGEO_SCRATCH_PROTOCOL}://pangeo-scratch/${JUPYTERHUB_USERNAME}/"
+if ! [[ -z "${PANGEO_SCRATCH_PREFIX}" ]] && ! [[ -z "${JUPYTERHUB_USERNAME}" ]]; then
+    export PANGEO_SCRATCH="${PANGEO_SCRATCH_PREFIX}/${JUPYTERHUB_USERNAME}/"
 fi
 
 # ==== ONLY EDIT WITHIN THIS BLOCK =====

--- a/ml-notebook/start
+++ b/ml-notebook/start
@@ -3,6 +3,11 @@
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 
 export PANGEO_ENV="ml-notebook"
+if [[ -z "${PANGEO_SCRATCH_PROTOCOL}" ]]; then
+    :
+else
+    export PANGEO_SCRATCH="${PANGEO_SCRATCH_PROTOCOL}://pangeo-scratch/${JUPYTERHUB_USERNAME}/"
+fi
 
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 

--- a/pangeo-notebook/start
+++ b/pangeo-notebook/start
@@ -3,10 +3,8 @@
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 
 export PANGEO_ENV="pangeo-notebook"
-if [[ -z "${PANGEO_SCRATCH_PROTOCOL}" ]]; then
-    :
-else
-    export PANGEO_SCRATCH="${PANGEO_SCRATCH_PROTOCOL}://pangeo-scratch/${JUPYTERHUB_USERNAME}/"
+if ! [[ -z "${PANGEO_SCRATCH_PREFIX}" ]] && ! [[ -z "${JUPYTERHUB_USERNAME}" ]]; then
+    export PANGEO_SCRATCH="${PANGEO_SCRATCH_PREFIX}/${JUPYTERHUB_USERNAME}/"
 fi
 
 # ==== ONLY EDIT WITHIN THIS BLOCK =====

--- a/pangeo-notebook/start
+++ b/pangeo-notebook/start
@@ -3,6 +3,11 @@
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 
 export PANGEO_ENV="pangeo-notebook"
+if [[ -z "${PANGEO_SCRATCH_PROTOCOL}" ]]; then
+    :
+else
+    export PANGEO_SCRATCH="${PANGEO_SCRATCH_PROTOCOL}://pangeo-scratch/${JUPYTERHUB_USERNAME}/"
+fi
 
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 


### PR DESCRIPTION
xref https://github.com/pangeo-data/pangeo-cloud-federation/issues/610,
https://github.com/pangeo-data/pangeo/pull/780. This adds a
PANGEO_SCRATCH environment variable. It relies on the existence of

1. PANGEO_SCRATCH_PROTOCOL
2. JUPYTERHUB_USERNAME

And combines those to form something like
`PANGEO_SCRATCH=gcs://pangeo-scratch/tomaugspurger`

We'll need to update the helm charts to set `PANGEO_SCRATCH_PROTOCOL` to be `s3` or `gcs`. This is a bit convoluted but I couldn't think of a simpler way.