### PR TITLE
Add gsw

### DIFF
--- a/pangeo-notebook/environment.yml
+++ b/pangeo-notebook/environment.yml
@@ -16,6 +16,7 @@ dependencies:
  - gcsfs
  - geopandas
  - geoviews-core
+ - gsw
  - h5netcdf
  - h5py
  - holoviews


### PR DESCRIPTION
The oceanographers will need this.

Now that `pangeo-notebook` is the image for our GCP cluster, this is probably the first of many requests we will get for domain-specific packages. Are we okay with that here?