### PR TITLE
Adding cfgrib to notebook env

### DIFF
--- a/pangeo-notebook/environment.yml
+++ b/pangeo-notebook/environment.yml
@@ -9,6 +9,7 @@ dependencies:
  - bottleneck
  - boto3
  - cartopy
+ - cfgrib
  - ciso
  - dask-ml
  - datashader>=0.11


### PR DESCRIPTION
/condalock
Adding cfgrib allows us to run the [xarray GRIB example notebook](http://xarray.pydata.org/en/stable/examples/ERA5-GRIB-example.html)