### PR TITLE
added esmpy and specified cartopy version

### DIFF
--- a/base-notebook/conda-linux-64.lock
+++ b/base-notebook/conda-linux-64.lock
@@ -13,7 +13,7 @@ https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-9.3.0-h24d8f2e_16.tar.
 https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.16.1-h516909a_3.tar.bz2#8d0f54b0a09bb496dea3f8dae0c551e4
 https://conda.anaconda.org/conda-forge/linux-64/icu-67.1-he1b5a44_0.tar.bz2#7ced6a5e5c94726af797d2b5a2b09228
 https://conda.anaconda.org/conda-forge/linux-64/jpeg-9d-h516909a_0.tar.bz2#aa82d2e6e1fa196bf4addd7ebc71a807
-https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_0.tar.bz2#36e6673f382c1597b66d24851957ce25
+https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2#6f8720dff19e17ce5d48cfe7f3d2f0a3
 https://conda.anaconda.org/conda-forge/linux-64/libffi-3.2.1-he1b5a44_1007.tar.bz2#11389072d7d6036fd811c3d9460475cd
 https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.10-pthreads_hb3c22a3_4.tar.bz2#8e3914247353e97a184909dbee132bfb
 https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h516909a_0.tar.bz2#3475e9e7c8c9ead7f75c70b7703cb100
@@ -36,7 +36,7 @@ https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.10-hed695b0_0.tar.bz2#9a3
 https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.2-he1b5a44_3.tar.bz2#d9e734dd2b3da4e4380c9c98e6a78b40
 https://conda.anaconda.org/conda-forge/linux-64/zstd-1.4.5-h6597ccf_2.tar.bz2#d60d50f369d40f9787878cdd866fc9d3
 https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.2-he06d7ca_0.tar.bz2#520fb55b5f6e29179499000b8107fe0a
-https://conda.anaconda.org/conda-forge/linux-64/krb5-1.17.1-hfafb76e_2.tar.bz2#c6933e0a4a7145b747064d0856880ed0
+https://conda.anaconda.org/conda-forge/linux-64/krb5-1.17.1-hfafb76e_3.tar.bz2#b9c0993124fbf5f4ccf37fd00d6a3705
 https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.8.0-17_openblas.tar.bz2#28f6376d1c4ca5e0fc287fb0484e37a1
 https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.8.0-17_openblas.tar.bz2#09cfbcdb4888dc9010b4cbc60e55c6ad
 https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.1.0-hc7e4089_6.tar.bz2#fa73bbe576ceb0c200a232c7956d8661
@@ -125,7 +125,7 @@ https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-1.7.0-0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-4.6.3-py37hc8dfbb8_1.tar.bz2#2169191b3df60024143e88aa047454ae
 https://conda.anaconda.org/conda-forge/noarch/mako-1.1.3-pyh9f0ad1d_0.tar.bz2#7c87121b0244cf6a1f44a1df12a846ea
 https://conda.anaconda.org/conda-forge/linux-64/pandas-1.1.1-py37h3340039_0.tar.bz2#71abf032e05e883ca07cde9bee13c525
-https://conda.anaconda.org/conda-forge/linux-64/setuptools-50.0.0-py37hc8dfbb8_0.tar.bz2#dfe82310e213b8b6d659336f9d6a7765
+https://conda.anaconda.org/conda-forge/linux-64/setuptools-49.6.0-py37hc8dfbb8_0.tar.bz2#295f9ca18c458eed106612b534a5990e
 https://conda.anaconda.org/conda-forge/linux-64/terminado-0.8.3-py37hc8dfbb8_1.tar.bz2#787037d7513630b8b94fe8848c8cabf2
 https://conda.anaconda.org/conda-forge/linux-64/yarl-1.3.0-py37h516909a_1000.tar.bz2#e8c9283008a914a4be78617fc2556c94
 https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.6.2-py37h516909a_0.tar.bz2#005bd1048aea096cf153a50cbcd44b44
@@ -152,7 +152,7 @@ https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.5-pyh9f0ad1d_1.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/dask-2.25.0-py_0.tar.bz2#64f4f24acb6a03be330f8f0e53612ff3
 https://conda.anaconda.org/conda-forge/noarch/kubernetes_asyncio-11.3.0-pyh9f0ad1d_0.tar.bz2#c95a80c5b0bfb7b38a9726c5b0f873d8
 https://conda.anaconda.org/conda-forge/linux-64/nbconvert-5.6.1-py37hc8dfbb8_1.tar.bz2#2f7e5d51e31ea55b21efcdc07d6b1cd2
-https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.6-py_0.tar.bz2#1a9b505ec4793f31ca4ad46c6392606e
+https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.7-py_0.tar.bz2#32341741e1d778b2c54bb42191cf8571
 https://conda.anaconda.org/conda-forge/noarch/requests-2.24.0-pyh9f0ad1d_0.tar.bz2#786ef230ca5cf2536e9dee910fdf4f9f
 https://conda.anaconda.org/conda-forge/noarch/adal-1.2.4-pyh9f0ad1d_0.tar.bz2#6d2380a60f8f4ed1050999f9eebc9a84
 https://conda.anaconda.org/conda-forge/linux-64/dask-gateway-0.8.0-py37hc8dfbb8_0.tar.bz2#ec047b425b9408bab186456299ecd910

--- a/ml-notebook/conda-linux-64.lock
+++ b/ml-notebook/conda-linux-64.lock
@@ -30,7 +30,7 @@ https://conda.anaconda.org/conda-forge/linux-64/json-c-0.13.1-hbfbb72e_1002.tar.
 https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-h516909a_2.tar.bz2#d999c4f5609fc17baf2caf61e9866d23
 https://conda.anaconda.org/conda-forge/linux-64/lerc-2.2-he1b5a44_0.tar.bz2#16e2b6c40c90b14e03dd697996acfa80
 https://conda.anaconda.org/conda-forge/linux-64/libaec-1.0.4-he1b5a44_1.tar.bz2#ef627970549f6ebd28e4f81d437280a5
-https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_0.tar.bz2#36e6673f382c1597b66d24851957ce25
+https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2#6f8720dff19e17ce5d48cfe7f3d2f0a3
 https://conda.anaconda.org/conda-forge/linux-64/libffi-3.2.1-he1b5a44_1007.tar.bz2#11389072d7d6036fd811c3d9460475cd
 https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.16-h516909a_0.tar.bz2#5c0f338a513a2943c659ae619fca9211
 https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.10-pthreads_hb3c22a3_4.tar.bz2#8e3914247353e97a184909dbee132bfb
@@ -84,7 +84,7 @@ https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.2-he1b5a44_3.tar.bz2#
 https://conda.anaconda.org/conda-forge/linux-64/zstd-1.4.5-h6597ccf_2.tar.bz2#d60d50f369d40f9787878cdd866fc9d3
 https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.2-he06d7ca_0.tar.bz2#520fb55b5f6e29179499000b8107fe0a
 https://conda.anaconda.org/conda-forge/linux-64/kealib-1.4.13-h33137a7_1.tar.bz2#ce5dd66ba674ffc664580aefcc1101b7
-https://conda.anaconda.org/conda-forge/linux-64/krb5-1.17.1-hfafb76e_2.tar.bz2#c6933e0a4a7145b747064d0856880ed0
+https://conda.anaconda.org/conda-forge/linux-64/krb5-1.17.1-hfafb76e_3.tar.bz2#b9c0993124fbf5f4ccf37fd00d6a3705
 https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.8.0-17_openblas.tar.bz2#28f6376d1c4ca5e0fc287fb0484e37a1
 https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hb574062_1011.tar.bz2#41192213fb45d65f1a5570acc9ddadcd
 https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.8.0-17_openblas.tar.bz2#09cfbcdb4888dc9010b4cbc60e55c6ad
@@ -236,7 +236,7 @@ https://conda.anaconda.org/conda-forge/linux-64/pandas-1.1.1-py37h3340039_0.tar.
 https://conda.anaconda.org/conda-forge/linux-64/poppler-0.87.0-h4190859_1.tar.bz2#5ea1a09933dd7e3820bf59676c7c76f7
 https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.1.1-py37h03ebfcd_1.tar.bz2#ee0c89ac43ea424a4b38bca79cbd6cab
 https://conda.anaconda.org/conda-forge/linux-64/scipy-1.5.2-py37hb14ef9d_0.tar.bz2#1fd2af7d7979bc724e98cc36814386c3
-https://conda.anaconda.org/conda-forge/linux-64/setuptools-50.0.0-py37hc8dfbb8_0.tar.bz2#dfe82310e213b8b6d659336f9d6a7765
+https://conda.anaconda.org/conda-forge/linux-64/setuptools-49.6.0-py37hc8dfbb8_0.tar.bz2#295f9ca18c458eed106612b534a5990e
 https://conda.anaconda.org/conda-forge/linux-64/shapely-1.7.1-py37hedb1597_0.tar.bz2#8fb3f487ed9f692468a50ce2dcfbd912
 https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2#cb83a3d6ecf73f50117635192414426a
 https://conda.anaconda.org/conda-forge/linux-64/terminado-0.8.3-py37hc8dfbb8_1.tar.bz2#787037d7513630b8b94fe8848c8cabf2
@@ -279,7 +279,7 @@ https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.0.1-py_0.tar.bz2#faaf2a
 https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.1.5-py37h0492a4a_1.tar.bz2#b35897e60013a24843954d546e45ecab
 https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.17.2-py37h0da4684_1.tar.bz2#37279ee84bc3eb6bcaae0752d0001da4
 https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-0.23.2-py37h6785257_0.tar.bz2#8732f613eebcc64f8f5d97c58aff56e7
-https://conda.anaconda.org/conda-forge/noarch/sparse-0.11.0-py_0.tar.bz2#0c7b279a0adf4fa60a061229f0fefba7
+https://conda.anaconda.org/conda-forge/noarch/sparse-0.11.1-py_0.tar.bz2#a1da8b721a3f935a820ad69930a10e04
 https://repo.anaconda.com/pkgs/main/linux-64/tensorflow-base-2.2.0-gpu_py37h8a81be8_0.conda#d37108dbc6e65147e41aa3f230750558
 https://conda.anaconda.org/conda-forge/noarch/tensorflow-estimator-2.2.0-pyh95af2a2_0.tar.bz2#e8ad826a75a9866f3f3ef5cc92be3b6e
 https://conda.anaconda.org/conda-forge/noarch/urllib3-1.25.10-py_0.tar.bz2#82cde2a532177697e42a090add881db8
@@ -289,7 +289,7 @@ https://conda.anaconda.org/conda-forge/noarch/dask-2.25.0-py_0.tar.bz2#64f4f24ac
 https://conda.anaconda.org/conda-forge/linux-64/fiona-1.8.13-py37h0492a4a_1.tar.bz2#6c93a9c93907eddf4ac923e436f6840f
 https://conda.anaconda.org/conda-forge/noarch/kubernetes_asyncio-11.3.0-pyh9f0ad1d_0.tar.bz2#c95a80c5b0bfb7b38a9726c5b0f873d8
 https://conda.anaconda.org/conda-forge/linux-64/nbconvert-5.6.1-py37hc8dfbb8_1.tar.bz2#2f7e5d51e31ea55b21efcdc07d6b1cd2
-https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.6-py_0.tar.bz2#1a9b505ec4793f31ca4ad46c6392606e
+https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.7-py_0.tar.bz2#32341741e1d778b2c54bb42191cf8571
 https://conda.anaconda.org/conda-forge/noarch/requests-2.24.0-pyh9f0ad1d_0.tar.bz2#786ef230ca5cf2536e9dee910fdf4f9f
 https://conda.anaconda.org/conda-forge/noarch/adal-1.2.4-pyh9f0ad1d_0.tar.bz2#6d2380a60f8f4ed1050999f9eebc9a84
 https://conda.anaconda.org/conda-forge/noarch/aiobotocore-1.1.0-py_0.tar.bz2#2c8b33b285e209d6dc5e9d5956e2242d

--- a/pangeo-notebook/conda-linux-64.lock
+++ b/pangeo-notebook/conda-linux-64.lock
@@ -1,5 +1,5 @@
 # platform: linux-64
-# env_hash: 2755b487b921bfcd66c91b02ca91a695912806bcc4e6205317edef10e0b976b8
+# env_hash: 88f6e9f2c662b13c88f99bb0cf78effd00db1dd80c5254dfea4a583195e881dd
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2#9a66894dfd07c4510beb6b3f9672ccc0
 https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
@@ -7,6 +7,7 @@ https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2020.6.20-hecda0
 https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.34-hc38a660_9.tar.bz2#aa1e7603f8dd36f8d60026cda3f1fb2c
 https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-7.5.0-hdf63c60_16.tar.bz2#d403b27c431064370f9d1b1962f8a86b
 https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-9.3.0-hdf63c60_16.tar.bz2#2c7c23cdad4f42f924d19029ef97475c
+https://conda.anaconda.org/conda-forge/linux-64/mpi-1.0-mpich.tar.bz2#c1fcff3417b5a22bbc4cf6e8c23648cf
 https://conda.anaconda.org/conda-forge/linux-64/pandoc-2.10.1-h516909a_0.tar.bz2#8101ef00bcd1e337b62807c3671a64ac
 https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.9-1.tar.bz2#1fef1ac4c55eec7cde779d89c8d20cc6
 https://conda.anaconda.org/conda-forge/linux-64/libgomp-9.3.0-h24d8f2e_16.tar.bz2#48f89ebfddb4ac93e74b0f4ab14c4a13
@@ -29,7 +30,7 @@ https://conda.anaconda.org/conda-forge/linux-64/json-c-0.13.1-hbfbb72e_1002.tar.
 https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-h516909a_2.tar.bz2#d999c4f5609fc17baf2caf61e9866d23
 https://conda.anaconda.org/conda-forge/linux-64/lerc-2.2-he1b5a44_0.tar.bz2#16e2b6c40c90b14e03dd697996acfa80
 https://conda.anaconda.org/conda-forge/linux-64/libaec-1.0.4-he1b5a44_1.tar.bz2#ef627970549f6ebd28e4f81d437280a5
-https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_0.tar.bz2#36e6673f382c1597b66d24851957ce25
+https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2#6f8720dff19e17ce5d48cfe7f3d2f0a3
 https://conda.anaconda.org/conda-forge/linux-64/libffi-3.2.1-he1b5a44_1007.tar.bz2#11389072d7d6036fd811c3d9460475cd
 https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.16-h516909a_0.tar.bz2#5c0f338a513a2943c659ae619fca9211
 https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.10-pthreads_hb3c22a3_4.tar.bz2#8e3914247353e97a184909dbee132bfb
@@ -41,6 +42,7 @@ https://conda.anaconda.org/conda-forge/linux-64/libuv-1.34.0-h516909a_0.tar.bz2#
 https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.1.0-h516909a_3.tar.bz2#3d543511584978d6e22b6c194ae3b81e
 https://conda.anaconda.org/conda-forge/linux-64/libzopfli-1.0.3-he1b5a44_0.tar.bz2#8728700e3541000fe61682f3869bf4a1
 https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.2-he1b5a44_3.tar.bz2#b2e54aad8640e7a877d2280d3ebfe85b
+https://conda.anaconda.org/conda-forge/linux-64/mpich-3.3.2-hc856adb_0.tar.bz2#770341e8023d3614e7c05cec34368591
 https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.2-he1b5a44_1.tar.bz2#d3da4932f3d8e6b3c81fcf177d1e6eab
 https://conda.anaconda.org/conda-forge/linux-64/openssl-1.1.1g-h516909a_1.tar.bz2#6fdcd20ec22aeffa10b6102bccc47e7f
 https://conda.anaconda.org/conda-forge/linux-64/pcre-8.44-he1b5a44_0.tar.bz2#e647d89cd5cdf62760cf283a001841ff
@@ -66,7 +68,7 @@ https://conda.anaconda.org/conda-forge/linux-64/brunsli-0.1-he1b5a44_0.tar.bz2#d
 https://conda.anaconda.org/conda-forge/linux-64/gettext-0.19.8.1-hc5be6a0_1002.tar.bz2#8c2f1de42f9eec059418f3083f03cabc
 https://conda.anaconda.org/conda-forge/linux-64/glog-0.4.0-h49b9bf7_3.tar.bz2#d763c0076c32135a4fc8a5857d4fd2ba
 https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.13-hf30be14_1003.tar.bz2#7f3e92154c3397e085ae1c37eb4975c5
-https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.10.5-nompi_h3c11f04_1104.tar.bz2#4ab54adc3774e9da616905a0090affed
+https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.10.6-mpi_mpich_ha7d0aea_1.tar.bz2#85407ad14d2b32e73f633d027ae67ad7
 https://conda.anaconda.org/conda-forge/linux-64/jasper-1.900.1-h07fcdf6_1006.tar.bz2#babe76b3c95cc3e9005a66855ffe4e21
 https://conda.anaconda.org/conda-forge/linux-64/libblas-3.8.0-17_openblas.tar.bz2#fdd1790e564778bf0c616e639badfe58
 https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2#4d331e44109e3f0e19b4cb8f9b82f3e1
@@ -87,8 +89,8 @@ https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.2-he1b5a44_3.tar.bz2#
 https://conda.anaconda.org/conda-forge/linux-64/zstd-1.4.5-h6597ccf_2.tar.bz2#d60d50f369d40f9787878cdd866fc9d3
 https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.2-he06d7ca_0.tar.bz2#520fb55b5f6e29179499000b8107fe0a
 https://conda.anaconda.org/conda-forge/linux-64/grpc-cpp-1.30.2-heedbac9_0.tar.bz2#c1268fe9a02d36e76a560ded61ee4e8a
-https://conda.anaconda.org/conda-forge/linux-64/kealib-1.4.13-hec59c27_0.tar.bz2#b72884a415c3b6d694914fa069bf43c4
-https://conda.anaconda.org/conda-forge/linux-64/krb5-1.17.1-hfafb76e_2.tar.bz2#c6933e0a4a7145b747064d0856880ed0
+https://conda.anaconda.org/conda-forge/linux-64/kealib-1.4.13-h33137a7_1.tar.bz2#ce5dd66ba674ffc664580aefcc1101b7
+https://conda.anaconda.org/conda-forge/linux-64/krb5-1.17.1-hfafb76e_3.tar.bz2#b9c0993124fbf5f4ccf37fd00d6a3705
 https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.8.0-17_openblas.tar.bz2#28f6376d1c4ca5e0fc287fb0484e37a1
 https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hb574062_1011.tar.bz2#41192213fb45d65f1a5570acc9ddadcd
 https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.8.0-17_openblas.tar.bz2#09cfbcdb4888dc9010b4cbc60e55c6ad
@@ -200,13 +202,13 @@ https://conda.anaconda.org/conda-forge/noarch/docrep-0.3.0-pyh9f0ad1d_0.tar.bz2#
 https://conda.anaconda.org/conda-forge/linux-64/entrypoints-0.3-py37hc8dfbb8_1001.tar.bz2#d2022cd098dbc7806a845669e9f23621
 https://conda.anaconda.org/conda-forge/noarch/fasteners-0.14.1-py_3.tar.bz2#8af0bf3cfe806fb001d9923b4fe1594b
 https://conda.anaconda.org/conda-forge/linux-64/future-0.18.2-py37hc8dfbb8_1.tar.bz2#035a07820788119b9903bf568f0d5b7e
-https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.5.1-h05acad5_10.tar.bz2#0eaf16074e7b9876524156ca8b4cf25c
+https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.6.0-h05acad5_0.tar.bz2#e2787ecd88545ebb0f273a4ec40da84e
 https://conda.anaconda.org/conda-forge/noarch/graphql-relay-3.0.0-py_0.tar.bz2#34ee85533bd837b9b016265215308e81
 https://conda.anaconda.org/conda-forge/linux-64/importlib-metadata-1.7.0-py37hc8dfbb8_0.tar.bz2#c6b612afebd9dea4557d0281fa090ec5
 https://conda.anaconda.org/conda-forge/linux-64/jedi-0.17.2-py37hc8dfbb8_0.tar.bz2#977e3d0e255c6805aa201aeea428fbc9
 https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.2.0-py37h99015e2_0.tar.bz2#ac7fc9ebc7d09372e933edd2b5b783ed
 https://conda.anaconda.org/conda-forge/linux-64/libdap4-3.20.6-h1d1bd15_1.tar.bz2#4fd50fa8f799f2070f7f8f27cfc95ae5
-https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.7.4-nompi_h9f9fd6a_101.tar.bz2#add87f9ca69bac2671898657332f9ec4
+https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.7.4-mpi_mpich_hfd9c5b6_5.tar.bz2#5e4a8918bbeead83c4be65a297133e56
 https://conda.anaconda.org/conda-forge/linux-64/libspatialite-4.3.0a-h2482549_1038.tar.bz2#b2ee2d89c71b551d4ec13ac5149fd349
 https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.34.0-py37h5202443_1.tar.bz2#70369509cff2a4735fbab44e71982bbb
 https://conda.anaconda.org/conda-forge/linux-64/lxml-4.5.2-py37he3881c9_0.tar.bz2#36cab057ef241d882aaead9ead0d40de
@@ -214,6 +216,7 @@ https://conda.anaconda.org/conda-forge/linux-64/lz4-3.1.0-py37h5a7ed16_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/markupsafe-1.1.1-py37h8f50634_1.tar.bz2#3a1f9e93d5bed65a9875eb2e5805cf0d
 https://conda.anaconda.org/conda-forge/noarch/marshmallow-oneofschema-2.0.1-py_0.tar.bz2#71aa651bcd1dd06ca7efc84853d5d825
 https://conda.anaconda.org/conda-forge/linux-64/mistune-0.8.4-py37h8f50634_1001.tar.bz2#e84446dacc5977ffdd2eee48d1680ea7
+https://conda.anaconda.org/conda-forge/linux-64/mpi4py-3.0.3-py37h0c5ec45_1.tar.bz2#b48c00f649d4da2d823c563a9c132b3b
 https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.0-py37h99015e2_1.tar.bz2#7fc501bc4c0604e1b98255d0b13959df
 https://conda.anaconda.org/conda-forge/linux-64/multidict-4.7.5-py37h8f50634_1.tar.bz2#a2ce8958425719eac43739946bd930bb
 https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2#1073dc92c8f247d94ac14dd79ca0bbec
@@ -227,7 +230,6 @@ https://conda.anaconda.org/conda-forge/linux-64/pillow-7.2.0-py37h718be6c_1.tar.
 https://conda.anaconda.org/conda-forge/linux-64/promise-2.3-py37hc8dfbb8_1.tar.bz2#21547a8b8f90c7824f81293d0b2e3520
 https://conda.anaconda.org/conda-forge/linux-64/psutil-5.7.2-py37h8f50634_0.tar.bz2#63baa94d2f114c2c47b1893b897582b2
 https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.2.7-py_0.tar.bz2#ad1e886d09700b2304975335f714bd9c
-https://conda.anaconda.org/conda-forge/linux-64/pybind11-2.5.0-py37h99015e2_0.tar.bz2#895006eca6b335e6076c79250d0a231c
 https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2#55ec526f95e0959de3f68bc6289a20da
 https://conda.anaconda.org/conda-forge/linux-64/pycurl-7.43.0.5-py37hce7685b_2.tar.bz2#ec73a00fa381b6d756e9918307b19733
 https://conda.anaconda.org/conda-forge/linux-64/pydantic-1.6.1-py37h8f50634_0.tar.bz2#1fc487c944e999720ae6bd7951aa6b21
@@ -246,7 +248,7 @@ https://conda.anaconda.org/conda-forge/linux-64/rtree-0.9.4-py37h8526d28_1.tar.b
 https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.0-py37h8f50634_1.tar.bz2#71717a66629f873f5283b5cdb0f995dc
 https://conda.anaconda.org/conda-forge/linux-64/simplejson-3.17.2-py37h8f50634_0.tar.bz2#81d40f82c1701cccd5db0fb9b97c25c4
 https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-1.3.19-py37h8f50634_0.tar.bz2#730796d5a238139757fc891611c1aad9
-https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.0.8-h3effe38_0.tar.bz2#239263a51f73882a7d6fee67a368950d
+https://conda.anaconda.org/conda-forge/linux-64/tiledb-1.7.7-h8efa9f0_3.tar.bz2#ac28be96aecef6aa789ddda3c3c444d1
 https://conda.anaconda.org/conda-forge/linux-64/tornado-6.0.4-py37h8f50634_1.tar.bz2#fd1d04c8e4cf93219ffee974e36249ee
 https://conda.anaconda.org/conda-forge/linux-64/traitlets-4.3.3-py37hc8dfbb8_1.tar.bz2#d565e0456c21e6aa521f79889a5da1ab
 https://conda.anaconda.org/conda-forge/noarch/trollsift-0.3.4-py_1.tar.bz2#9fa458a65b7f1e59fdd6848fe286bf07
@@ -266,28 +268,28 @@ https://conda.anaconda.org/conda-forge/noarch/croniter-0.3.30-py_0.tar.bz2#d2872
 https://conda.anaconda.org/conda-forge/linux-64/cryptography-3.1-py37hb09aad4_0.tar.bz2#e77b328cfe6bd416096ca39bd65ae090
 https://conda.anaconda.org/conda-forge/noarch/dask-core-2.25.0-py_0.tar.bz2#3724aa726cd0375a22d3cf286693334b
 https://conda.anaconda.org/conda-forge/noarch/datashape-0.5.4-py_1.tar.bz2#50ddfce434ea596fc4497085f403a9d5
-https://conda.anaconda.org/conda-forge/linux-64/eccodes-2.17.0-h59f7be3_1.tar.bz2#bf61e049a40d62990361f070bb45a855
+https://conda.anaconda.org/conda-forge/linux-64/eccodes-2.18.0-hf05d9b7_0.tar.bz2#b9811e45236899e7a97216cc64a988d0
 https://conda.anaconda.org/conda-forge/noarch/eofs-1.4.0-py_0.tar.bz2#6e166cd37cfeadefcfca1ffe00f222bb
 https://conda.anaconda.org/conda-forge/noarch/graphene-1.4-py_0.tar.bz2#241bd7620dbbdabe1a1da30ed9d48de6
 https://conda.anaconda.org/conda-forge/linux-64/gsw-3.3.1-py37h03ebfcd_2.tar.bz2#45aec32e097313d06c8495789cb9571d
-https://conda.anaconda.org/conda-forge/linux-64/h5py-2.10.0-nompi_py37h513d04c_102.tar.bz2#9a9ca5e194dc9c06104d1cc15c81e6b8
+https://conda.anaconda.org/conda-forge/linux-64/h5py-2.10.0-nompi_py37h90cd8ad_104.tar.bz2#a09536cc7c39e0b7c3dc65d37323afce
 https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2020.5.30-py37hda6ee5b_2.tar.bz2#0825c902e911a1b9ef167c11c24b8a81
 https://conda.anaconda.org/conda-forge/noarch/imageio-2.9.0-py_0.tar.bz2#62ad9e579278e777d4abaa8c9312b6a7
 https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-1.7.0-0.tar.bz2#3e6503b25200f60149cce699a47cf09e
 https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-4.6.3-py37hc8dfbb8_1.tar.bz2#2169191b3df60024143e88aa047454ae
 https://conda.anaconda.org/conda-forge/noarch/mako-1.1.3-pyh9f0ad1d_0.tar.bz2#7c87121b0244cf6a1f44a1df12a846ea
 https://conda.anaconda.org/conda-forge/noarch/markdown-3.2.2-py_0.tar.bz2#f09d9ef8bd8db224f56d1442725249a0
-https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.5.2-nompi_h45d7149_104.tar.bz2#40c6c4a5505172e84e5b96e86650e670
+https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.5.3-mpi_mpich_h3923e1a_0.tar.bz2#7565318d1b2c68319bb9a0f4b01996e0
 https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.6.4-py37he1b5a44_0.tar.bz2#b3430e11d4184d1de418b389bd76a7b6
 https://conda.anaconda.org/conda-forge/linux-64/pandas-1.1.1-py37h3340039_0.tar.bz2#71abf032e05e883ca07cde9bee13c525
 https://conda.anaconda.org/conda-forge/linux-64/pendulum-2.1.2-py37hc8dfbb8_0.tar.bz2#82383de5773e8c44b0cf7e1f29cbf414
-https://conda.anaconda.org/conda-forge/linux-64/poppler-0.67.0-h14e79db_8.tar.bz2#e20e05cc2efde07972b62414d02de883
+https://conda.anaconda.org/conda-forge/linux-64/poppler-0.87.0-h4190859_1.tar.bz2#5ea1a09933dd7e3820bf59676c7c76f7
 https://conda.anaconda.org/conda-forge/linux-64/pykdtree-1.3.1-py37h03ebfcd_1003.tar.bz2#9cc8f6bb163559dea6c677b0f467571c
 https://conda.anaconda.org/conda-forge/noarch/pyorbital-1.6.0-pyh9f0ad1d_0.tar.bz2#279247380d054a980565458462ec4140
 https://conda.anaconda.org/conda-forge/noarch/pystac-0.5.2-pyh9f0ad1d_0.tar.bz2#d4e2ad32dcd75f621a90014ca95ff508
 https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.1.1-py37h03ebfcd_1.tar.bz2#ee0c89ac43ea424a4b38bca79cbd6cab
 https://conda.anaconda.org/conda-forge/linux-64/scipy-1.5.2-py37hb14ef9d_0.tar.bz2#1fd2af7d7979bc724e98cc36814386c3
-https://conda.anaconda.org/conda-forge/linux-64/setuptools-50.0.0-py37hc8dfbb8_0.tar.bz2#dfe82310e213b8b6d659336f9d6a7765
+https://conda.anaconda.org/conda-forge/linux-64/setuptools-49.6.0-py37hc8dfbb8_0.tar.bz2#295f9ca18c458eed106612b534a5990e
 https://conda.anaconda.org/conda-forge/linux-64/shapely-1.7.1-py37hedb1597_0.tar.bz2#8fb3f487ed9f692468a50ce2dcfbd912
 https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2#cb83a3d6ecf73f50117635192414426a
 https://conda.anaconda.org/conda-forge/linux-64/terminado-0.8.3-py37hc8dfbb8_1.tar.bz2#787037d7513630b8b94fe8848c8cabf2
@@ -298,7 +300,7 @@ https://conda.anaconda.org/conda-forge/noarch/alembic-1.4.2-pyh9f0ad1d_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.1-py_0.tar.bz2#d36df15eaef96549ce6231e3088fba54
 https://conda.anaconda.org/conda-forge/noarch/bleach-3.1.5-pyh9f0ad1d_0.tar.bz2#fdd3428764b35bd251798db254a9bdea
 https://conda.anaconda.org/conda-forge/linux-64/distributed-2.25.0-py37hc8dfbb8_0.tar.bz2#1919fc335d55e853fb3d82461ba3908a
-https://conda.anaconda.org/conda-forge/linux-64/esmf-8.0.0-nompi_hb0fcdcb_6.tar.bz2#377a8d2da9e7d41936831281a44615b2
+https://conda.anaconda.org/conda-forge/linux-64/esmf-8.0.1-mpi_mpich_h213fab7_100.tar.bz2#29504ef252043bd4d84682a0379ea39e
 https://conda.anaconda.org/conda-forge/noarch/google-auth-1.20.1-py_0.tar.bz2#239af521a8f1171fa259385876e05ada
 https://conda.anaconda.org/conda-forge/linux-64/gunicorn-20.0.4-py37hc8dfbb8_1.tar.bz2#c4cfcb03f464b947de1dde55d153a167
 https://conda.anaconda.org/conda-forge/noarch/h5netcdf-0.8.1-py_0.tar.bz2#0181638a03dbead1e8b2ff3bdb54d24e
@@ -306,11 +308,11 @@ https://conda.anaconda.org/conda-forge/noarch/jinja2-2.11.2-pyh9f0ad1d_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/joblib-0.16.0-py_0.tar.bz2#101f7628023ff2d43479ab66c73c3f72
 https://conda.anaconda.org/conda-forge/linux-64/jsonschema-3.2.0-py37hc8dfbb8_1.tar.bz2#3bbfbc1c12652fc35a225180d7aeff19
 https://conda.anaconda.org/conda-forge/noarch/jupyter_client-6.1.7-py_0.tar.bz2#bcaa486602c05413da0808b82898f60a
-https://conda.anaconda.org/conda-forge/linux-64/libgdal-2.4.4-h5439ffd_1.tar.bz2#65c93e8b16bfdc081d275ccc8242d63a
+https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.0.4-he6a97d6_10.tar.bz2#1406182174b2ef9c7fc3ee8d7b907b91
 https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.3.1-py37hd478181_1.tar.bz2#8b282074b8c13ca9a6256dc4ff782c19
 https://conda.anaconda.org/conda-forge/noarch/mercantile-1.1.6-pyh9f0ad1d_0.tar.bz2#eaf86369fd910829b49a13a91fd0ee73
 https://conda.anaconda.org/conda-forge/noarch/munch-2.5.0-py_0.tar.bz2#31d9e9be500e25ff0050bc9f57a6bcd7
-https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.5.3-nompi_py37hec16513_103.tar.bz2#1274c6c94a897ee368fe64b1d5c41f98
+https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.5.4-nompi_py37hcbfd489_102.tar.bz2#00ec82c27a611297d864d80c889db14a
 https://conda.anaconda.org/conda-forge/noarch/networkx-2.5-py_0.tar.bz2#d836ad8453c22192357707026ca21653
 https://conda.anaconda.org/conda-forge/linux-64/numba-0.51.1-py37h9fdb41a_0.tar.bz2#c66e98c54a51ac34180f2aea9ca2a366
 https://conda.anaconda.org/conda-forge/noarch/parquet-cpp-1.5.1-2.tar.bz2#79a5f78c42817594ae016a7896521a97
@@ -324,7 +326,7 @@ https://conda.anaconda.org/conda-forge/linux-64/pyresample-1.16.0-py37h0da4684_0
 https://conda.anaconda.org/conda-forge/linux-64/python-geotiepoints-1.2.0-py37h03ebfcd_0.tar.bz2#5226f94de55d954bbbd3ccae466a76c3
 https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.16.10-py37h8f50634_0.tar.bz2#d159494f7fcbc1cb6da7a328d3676d1c
 https://conda.anaconda.org/conda-forge/noarch/tifffile-2020.8.25-py_0.tar.bz2#e7ee816ae254cc081f4e5ac18ddccd21
-https://conda.anaconda.org/conda-forge/linux-64/tiledb-py-0.6.6-py37haae2426_0.tar.bz2#81dd6cc20422e2637859bfc8530605e9
+https://conda.anaconda.org/conda-forge/linux-64/tiledb-py-0.5.9-py37ha852a99_1.tar.bz2#41e1cff2a2a13b0679b330af15a0a226
 https://conda.anaconda.org/conda-forge/noarch/xarray-0.16.0-py_0.tar.bz2#a9d4fbd79e09a857acbce265a028dac7
 https://conda.anaconda.org/conda-forge/noarch/zarr-2.4.0-py_0.tar.bz2#57d5031b1a07f73f6a671fba6eccbd2a
 https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.2.0-py37hc8dfbb8_0.tar.bz2#d3f9d9e1ca3ded7ab49c6aed027f33d2
@@ -332,9 +334,9 @@ https://conda.anaconda.org/conda-forge/noarch/branca-0.3.1-py_0.tar.bz2#d578d9c8
 https://conda.anaconda.org/conda-forge/noarch/certipy-0.1.3-py_0.tar.bz2#23486713ef5712923e7c57cae609b22e
 https://conda.anaconda.org/conda-forge/noarch/cfgrib-0.9.8.4-py_0.tar.bz2#901e4d9174eafde2a08abea34ce8a52f
 https://conda.anaconda.org/conda-forge/noarch/descartes-1.1.0-py_4.tar.bz2#32fa3526c15250ccf353f1ce905f50b3
-https://conda.anaconda.org/conda-forge/linux-64/esmpy-8.0.0-nompi_py37hf0e99fa_1.tar.bz2#c5582102897795a150c12f9cb43b06e5
+https://conda.anaconda.org/conda-forge/linux-64/esmpy-8.0.1-mpi_mpich_py37hef66020_100.tar.bz2#8fac966b1bc9bd4789f5553434c40306
 https://conda.anaconda.org/conda-forge/noarch/fastjmd95-0.1-pyh9f0ad1d_0.tar.bz2#2fc5139d3de2bfadd6ed80fe89526f2d
-https://conda.anaconda.org/conda-forge/linux-64/gdal-2.4.4-py37hf8c3989_1.tar.bz2#7f63601b59eba7c4082e4bfc1967db9d
+https://conda.anaconda.org/conda-forge/linux-64/gdal-3.0.4-py37h4b180d9_10.tar.bz2#eefb5bd62c913611ba6df8335e0b7caf
 https://conda.anaconda.org/conda-forge/noarch/jupyter_telemetry-0.0.5-py_0.tar.bz2#46d62a58c7dd1e6fcdaff59441285791
 https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.7-py_0.tar.bz2#7f9984ee165126ac09d9eb678052783d
 https://conda.anaconda.org/conda-forge/noarch/nc-time-axis-1.2.0-py_1.tar.bz2#f3158a5d335f0f44f09cf05d3fb4107e
@@ -342,21 +344,21 @@ https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.0.1-py_0.tar.bz2#faaf2a
 https://conda.anaconda.org/conda-forge/linux-64/pyarrow-1.0.1-py37h1234567_1_cpu.tar.bz2#b11cf2b0787fd2742765fef3e8c8b8e7
 https://conda.anaconda.org/conda-forge/linux-64/pytest-6.0.1-py37hc8dfbb8_0.tar.bz2#5361cccff2f12d67afe6251b15f24c93
 https://conda.anaconda.org/conda-forge/noarch/python-box-4.2.3-py_0.tar.bz2#6e99abc8d6e45e26f99e3aa1994c506e
-https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.1.5-py37hf4c872c_0.tar.bz2#576d5bb15396c47d73a3472c93d3b404
+https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.1.5-py37h0492a4a_1.tar.bz2#b35897e60013a24843954d546e45ecab
 https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.17.2-py37h0da4684_1.tar.bz2#37279ee84bc3eb6bcaae0752d0001da4
 https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-0.23.2-py37h6785257_0.tar.bz2#8732f613eebcc64f8f5d97c58aff56e7
-https://conda.anaconda.org/conda-forge/noarch/sparse-0.11.0-py_0.tar.bz2#0c7b279a0adf4fa60a061229f0fefba7
+https://conda.anaconda.org/conda-forge/noarch/sparse-0.11.1-py_0.tar.bz2#a1da8b721a3f935a820ad69930a10e04
 https://conda.anaconda.org/conda-forge/noarch/urllib3-1.25.10-py_0.tar.bz2#82cde2a532177697e42a090add881db8
 https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.11.3-py37hc8dfbb8_1.tar.bz2#4ac1fa1ea1460003da3e70d25e25dba3
 https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.5-pyh9f0ad1d_1.tar.bz2#ac581f74f00d4d9f5acec2449f310e70
 https://conda.anaconda.org/conda-forge/linux-64/xlayers-0.2.2-py37hf630d0d_0.tar.bz2#3c0eaf7a91335e54fb4160961da8ed34
 https://conda.anaconda.org/conda-forge/noarch/botocore-1.17.51-pyh9f0ad1d_0.tar.bz2#2e6eaec8706023e46ef7c746bd33aff4
 https://conda.anaconda.org/conda-forge/noarch/dask-2.25.0-py_0.tar.bz2#64f4f24acb6a03be330f8f0e53612ff3
-https://conda.anaconda.org/conda-forge/linux-64/fiona-1.8.9.post2-py37hdff7cfa_0.tar.bz2#5316d57699a8d12866a9dbf33d06e331
+https://conda.anaconda.org/conda-forge/linux-64/fiona-1.8.13-py37h0492a4a_1.tar.bz2#6c93a9c93907eddf4ac923e436f6840f
 https://conda.anaconda.org/conda-forge/noarch/kubernetes_asyncio-11.3.0-pyh9f0ad1d_0.tar.bz2#c95a80c5b0bfb7b38a9726c5b0f873d8
 https://conda.anaconda.org/conda-forge/linux-64/nbconvert-5.6.1-py37hc8dfbb8_1.tar.bz2#2f7e5d51e31ea55b21efcdc07d6b1cd2
 https://conda.anaconda.org/conda-forge/noarch/nbstripout-0.3.9-pyh9f0ad1d_0.tar.bz2#8c3a853fabd60794a292fbd9ab052c4d
-https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.6-py_0.tar.bz2#1a9b505ec4793f31ca4ad46c6392606e
+https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.7-py_0.tar.bz2#32341741e1d778b2c54bb42191cf8571
 https://conda.anaconda.org/conda-forge/noarch/requests-2.24.0-pyh9f0ad1d_0.tar.bz2#786ef230ca5cf2536e9dee910fdf4f9f
 https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.0.31-py_0.tar.bz2#e992dee8735947ab44ea24545a9a1d0d
 https://conda.anaconda.org/conda-forge/noarch/supermercado-0.1.1-pyh9f0ad1d_0.tar.bz2#f5ef456907fa6a8064677722f0f07729
@@ -389,7 +391,7 @@ https://conda.anaconda.org/conda-forge/noarch/xmitgcm-0.4.1-py_0.tar.bz2#af0a895
 https://conda.anaconda.org/conda-forge/noarch/xrft-0.2.0-py_0.tar.bz2#c6abd5881c4f4fa6eaa3497b9e812051
 https://conda.anaconda.org/conda-forge/linux-64/awscli-1.18.128-py37hc8dfbb8_0.tar.bz2#df424f083d41bfbf24d3314eed302c45
 https://conda.anaconda.org/conda-forge/noarch/boto3-1.14.51-pyh9f0ad1d_0.tar.bz2#7b488ed269398075ce46172de032e4f3
-https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.17.0-py37h17ca249_1015.tar.bz2#4a66bbd06462adc0d02f0113b75b05d1
+https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.18.0-py37h4b180d9_0.tar.bz2#b081f474a8b91ddd25b5476c752fe547
 https://conda.anaconda.org/conda-forge/noarch/colorcet-2.0.1-py_0.tar.bz2#aa65c1760b4ccc79d3be1fb3a7060de8
 https://conda.anaconda.org/conda-forge/noarch/dask-ml-1.6.0-py_0.tar.bz2#50c180dcf922eb1306202ad871975695
 https://conda.anaconda.org/conda-forge/noarch/fastapi-0.61.1-py_0.tar.bz2#cf0bc247ea8b1819c9553d47a308d40c

--- a/pangeo-notebook/environment.yml
+++ b/pangeo-notebook/environment.yml
@@ -8,13 +8,14 @@ dependencies:
  - awscli
  - bottleneck
  - boto3
- - cartopy
+ - cartopy>=0.18
  - cfgrib
  - ciso
  - dask-ml
  - datashader>=0.11
  - descartes
  - eofs
+ - esmpy
  - fastjmd95
  - fsspec
  - gcsfs


### PR DESCRIPTION
See #101 . For some reason, we also need to force cartopy >= 0.18 to get mpi installed.