### PR TITLE
add erddapy to notebook environment

### DIFF
--- a/base-notebook/conda-linux-64.lock
+++ b/base-notebook/conda-linux-64.lock
@@ -133,7 +133,7 @@ https://conda.anaconda.org/conda-forge/linux-64/pandas-1.1.3-py38hddd6c8b_2.tar.
 https://conda.anaconda.org/conda-forge/linux-64/setuptools-49.6.0-py38h924ce5b_2.tar.bz2#85f49978317e2f963ffd1d0989b16038
 https://conda.anaconda.org/conda-forge/linux-64/terminado-0.9.1-py38h32f6830_1.tar.bz2#f74ca1717f8a752cf1ec0fd0a0131389
 https://conda.anaconda.org/conda-forge/linux-64/yarl-1.6.2-py38h1e0a361_0.tar.bz2#f1f11f873392ada5f2f366e4d4067d7c
-https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.7.1-py38h1e0a361_0.tar.bz2#d39cc9005cfb76e3be0b0ca0d8436383
+https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.7.2-py38h1e0a361_0.tar.bz2#c7ad80e711e524a512d7c32b3e2a579a
 https://conda.anaconda.org/conda-forge/noarch/alembic-1.4.3-pyh9f0ad1d_0.tar.bz2#84c871138af479a1724d3c3634273dda
 https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.1-py_0.tar.bz2#d36df15eaef96549ce6231e3088fba54
 https://conda.anaconda.org/conda-forge/noarch/bleach-3.2.1-pyh9f0ad1d_0.tar.bz2#d4506316b85679972c0b78d4d1c0b701
@@ -164,7 +164,7 @@ https://conda.anaconda.org/conda-forge/noarch/adal-1.2.5-pyh9f0ad1d_0.tar.bz2#39
 https://conda.anaconda.org/conda-forge/linux-64/dask-gateway-0.8.0-py38h32f6830_0.tar.bz2#b73340a0204f94bfd5e2d2d36358f3f4
 https://conda.anaconda.org/conda-forge/linux-64/ipython-7.18.1-py38h1cdfbd6_1.tar.bz2#13360063217908a5ee2274563d943b30
 https://conda.anaconda.org/conda-forge/linux-64/jupyterhub-base-1.1.0-py38h32f6830_5.tar.bz2#90ece4e820ee4450227be2049dbeddb5
-https://conda.anaconda.org/conda-forge/linux-64/nbconvert-6.0.7-py38h32f6830_1.tar.bz2#f6007a2ab4e75710758aa633907f6360
+https://conda.anaconda.org/conda-forge/linux-64/nbconvert-6.0.7-py38h32f6830_2.tar.bz2#e0e9c704aee858ea8cbf248f64a67250
 https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.3.0-pyh9f0ad1d_0.tar.bz2#acdcfb3267ef1a8e576e84480a5e259d
 https://conda.anaconda.org/conda-forge/linux-64/ipykernel-5.3.4-py38h1cdfbd6_1.tar.bz2#2b31fc793aa78f0572bba6ee24e81358
 https://conda.anaconda.org/conda-forge/noarch/python-kubernetes-12.0.0-pyh9f0ad1d_0.tar.bz2#29fbe952d848de74819fb012de2525ba

--- a/base-notebook/packages.txt
+++ b/base-notebook/packages.txt
@@ -2,7 +2,7 @@ IT
 _libgcc_mutex-0.1
 _openmp_mutex-4.5
 adal-1.2.5
-aiohttp-3.7.1
+aiohttp-3.7.2
 alembic-1.4.3
 argon2-cffi-20.1.0
 async-timeout-3.0.1

--- a/ml-notebook/conda-linux-64.lock
+++ b/ml-notebook/conda-linux-64.lock
@@ -220,7 +220,7 @@ https://conda.anaconda.org/conda-forge/linux-64/websocket-client-0.57.0-py38h32f
 https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.12.1-py38h1e0a361_1.tar.bz2#c871ce1559ca06aeac7b6dbbebcf9357
 https://conda.anaconda.org/conda-forge/linux-64/yarl-1.6.2-py38h1e0a361_0.tar.bz2#f1f11f873392ada5f2f366e4d4067d7c
 https://conda.anaconda.org/conda-forge/noarch/zict-2.0.0-py_0.tar.bz2#4750152be22f24d695b3004c5e1712d3
-https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.7.1-py38h1e0a361_0.tar.bz2#d39cc9005cfb76e3be0b0ca0d8436383
+https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.7.2-py38h1e0a361_0.tar.bz2#c7ad80e711e524a512d7c32b3e2a579a
 https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-20.1.0-py38h1e0a361_2.tar.bz2#8823850e0c5eb18f8b59b6141ef34a50
 https://conda.anaconda.org/conda-forge/linux-64/brotlipy-0.7.0-py38h8df0ef7_1001.tar.bz2#1d928644b8bfd49b2e869609dd3e57a1
 https://conda.anaconda.org/conda-forge/linux-64/cftime-1.2.1-py38hab2c0dc_1.tar.bz2#777186ded2d850f3eab4ce7131c6c17c
@@ -302,14 +302,14 @@ https://conda.anaconda.org/conda-forge/linux-64/dask-gateway-0.8.0-py38h32f6830_
 https://conda.anaconda.org/conda-forge/noarch/intake-0.6.0-py_0.tar.bz2#1043778f4cd11dda4e7df45edfd12154
 https://conda.anaconda.org/conda-forge/linux-64/ipython-7.18.1-py38h1cdfbd6_1.tar.bz2#13360063217908a5ee2274563d943b30
 https://conda.anaconda.org/conda-forge/linux-64/jupyterhub-base-1.1.0-py38h32f6830_5.tar.bz2#90ece4e820ee4450227be2049dbeddb5
-https://conda.anaconda.org/conda-forge/linux-64/nbconvert-6.0.7-py38h32f6830_1.tar.bz2#f6007a2ab4e75710758aa633907f6360
+https://conda.anaconda.org/conda-forge/linux-64/nbconvert-6.0.7-py38h32f6830_2.tar.bz2#e0e9c704aee858ea8cbf248f64a67250
 https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.4.8-py38_0.conda#6a94f43172baa54f54d83d7ad8ba97cd
 https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.3.0-pyh9f0ad1d_0.tar.bz2#acdcfb3267ef1a8e576e84480a5e259d
 https://repo.anaconda.com/pkgs/main/noarch/colorcet-2.0.2-py_0.conda#63d4e66db2e99bd09bf7b8950044d42b
 https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-0.4.1-py_2.tar.bz2#116611db5925f952312e4c1e799936e2
 https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.4.0-py_0.tar.bz2#657133ce00e16fccd07e789ad4f92aea
 https://conda.anaconda.org/conda-forge/linux-64/ipykernel-5.3.4-py38h1cdfbd6_1.tar.bz2#2b31fc793aa78f0572bba6ee24e81358
-https://conda.anaconda.org/conda-forge/noarch/panel-0.9.7-py_0.tar.bz2#b5147a3905e3984233a7e29f690b50db
+https://conda.anaconda.org/conda-forge/noarch/panel-0.10.0-py_0.tar.bz2#75b25f0347a90e54b243391bc22898a3
 https://conda.anaconda.org/conda-forge/noarch/python-kubernetes-12.0.0-pyh9f0ad1d_0.tar.bz2#29fbe952d848de74819fb012de2525ba
 https://conda.anaconda.org/conda-forge/noarch/s3fs-0.5.1-py_0.tar.bz2#1b361daa3e5368132bdbdb7d12990da6
 https://conda.anaconda.org/conda-forge/noarch/dask-kubernetes-0.11.0-py_0.tar.bz2#baa10ba2d60965936f774a38206efbb3

--- a/ml-notebook/packages.txt
+++ b/ml-notebook/packages.txt
@@ -6,7 +6,7 @@ absl-py-0.10.0
 adal-1.2.5
 affine-2.3.0
 aiobotocore-1.1.2
-aiohttp-3.7.1
+aiohttp-3.7.2
 aioitertools-0.7.0
 alembic-1.4.3
 appdirs-1.4.4
@@ -210,7 +210,7 @@ pamela-1.0.0
 pandas-1.1.3
 pandoc-2.11.0.4
 pandocfilters-1.4.2
-panel-0.9.7
+panel-0.10.0
 pangeo-dask-2020.10.08
 pangeo-notebook-2020.10.08
 param-1.10.0

--- a/pangeo-notebook/conda-linux-64.lock
+++ b/pangeo-notebook/conda-linux-64.lock
@@ -1,5 +1,5 @@
 # platform: linux-64
-# env_hash: 443d1e5c0c266721f96bd5a82782aae771423f96d25f49f29c6fec5e1910f47c
+# env_hash: 4665c816ba6adc85ead167fddfd8e3804f8447675ee5debf76347787a574bf1d
 
 @EXPLICIT
 
@@ -359,7 +359,7 @@ https://conda.anaconda.org/conda-forge/linux-64/terminado-0.9.1-py38h32f6830_1.t
 https://conda.anaconda.org/conda-forge/noarch/traittypes-0.2.1-pyh9f0ad1d_2.tar.bz2#7d32ccb5334a6822c28af3e864550618
 https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.12.2-py38h32f6830_0.tar.bz2#1ca852350badb6590a8a7c54ea7efb4a
 https://conda.anaconda.org/conda-forge/linux-64/yarl-1.6.2-py38h1e0a361_0.tar.bz2#f1f11f873392ada5f2f366e4d4067d7c
-https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.7.1-py38h1e0a361_0.tar.bz2#d39cc9005cfb76e3be0b0ca0d8436383
+https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.7.2-py38h1e0a361_0.tar.bz2#c7ad80e711e524a512d7c32b3e2a579a
 https://conda.anaconda.org/conda-forge/noarch/alembic-1.4.3-pyh9f0ad1d_0.tar.bz2#84c871138af479a1724d3c3634273dda
 https://conda.anaconda.org/conda-forge/linux-64/atk-2.36.0-3.tar.bz2#a5f5a97a6d30e791618f212a8f8665d9
 https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.1-py_0.tar.bz2#d36df15eaef96549ce6231e3088fba54
@@ -423,7 +423,7 @@ https://conda.anaconda.org/conda-forge/noarch/supermercado-0.2.0-pyh9f0ad1d_0.ta
 https://conda.anaconda.org/conda-forge/noarch/urllib3-1.25.11-py_0.tar.bz2#4ce0599839b2b4418befe201e5f072fc
 https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.5-pyh9f0ad1d_2.tar.bz2#5266fcd697043c59621fda522b3d78ee
 https://conda.anaconda.org/conda-forge/linux-64/xlayers-0.2.2-py38h41a8863_1.tar.bz2#19e74b79d0116057e23ad8e07cd2d271
-https://conda.anaconda.org/conda-forge/noarch/botocore-1.19.4-pyh9f0ad1d_0.tar.bz2#207a24658c0f72caf2330b62b0fdd945
+https://conda.anaconda.org/conda-forge/noarch/botocore-1.19.5-pyh9f0ad1d_0.tar.bz2#711ec8ba67f4d1c54a12c0148a069a40
 https://conda.anaconda.org/conda-forge/noarch/dask-2.30.0-py_0.tar.bz2#4c8b8bec2dfac1beec0159c1979d6666
 https://conda.anaconda.org/conda-forge/noarch/geopandas-0.8.1-py_0.tar.bz2#77401947aaa42c713c69cdf8817e1df0
 https://conda.anaconda.org/conda-forge/linux-64/graphviz-2.42.3-h6939c30_2.tar.bz2#fc2252c1502dd31f0b894dc3c69fdffd
@@ -439,11 +439,12 @@ https://conda.anaconda.org/conda-forge/noarch/adal-1.2.5-pyh9f0ad1d_0.tar.bz2#39
 https://conda.anaconda.org/conda-forge/linux-64/dask-gateway-0.8.0-py38h32f6830_0.tar.bz2#b73340a0204f94bfd5e2d2d36358f3f4
 https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.2.0-py_1.tar.bz2#7c9c5295a0499bf56bbf084578618af5
 https://conda.anaconda.org/conda-forge/linux-64/docker-py-4.3.1-py38h32f6830_1.tar.bz2#a61d35a3cdf3d73027c1d07d55295feb
+https://conda.anaconda.org/conda-forge/noarch/erddapy-0.7.2-py_0.tar.bz2#54787bf5aa35fc7627bddfbde07b61d7
 https://conda.anaconda.org/conda-forge/noarch/intake-0.6.0-py_0.tar.bz2#1043778f4cd11dda4e7df45edfd12154
 https://conda.anaconda.org/conda-forge/linux-64/ipython-7.18.1-py38h1cdfbd6_1.tar.bz2#13360063217908a5ee2274563d943b30
 https://conda.anaconda.org/conda-forge/linux-64/jupyterhub-base-1.1.0-py38h32f6830_5.tar.bz2#90ece4e820ee4450227be2049dbeddb5
 https://conda.anaconda.org/conda-forge/noarch/mechanicalsoup-0.12.0-py_0.tar.bz2#c7b7572e25b5569898d7de99a4b135b5
-https://conda.anaconda.org/conda-forge/linux-64/nbconvert-6.0.7-py38h32f6830_1.tar.bz2#f6007a2ab4e75710758aa633907f6360
+https://conda.anaconda.org/conda-forge/linux-64/nbconvert-6.0.7-py38h32f6830_2.tar.bz2#e0e9c704aee858ea8cbf248f64a67250
 https://conda.anaconda.org/conda-forge/noarch/owslib-0.20.0-py_0.tar.bz2#d9f1280ab8723862dd8b30f4f9c241e0
 https://conda.anaconda.org/conda-forge/noarch/pooch-1.2.0-py_0.tar.bz2#bcd9403c19cf7c8b8b0874856aa8fa38
 https://conda.anaconda.org/conda-forge/noarch/pycamhd-0.7.0-py_0.tar.bz2#49407af9fedc76cd0046b331acf8c1c9
@@ -463,8 +464,8 @@ https://conda.anaconda.org/conda-forge/noarch/xgcm-0.5.1-py_0.tar.bz2#935f4608a9
 https://conda.anaconda.org/conda-forge/noarch/xhistogram-0.1.1-py_0.tar.bz2#014c84ba10debba421f42ac55006bab8
 https://conda.anaconda.org/conda-forge/noarch/xmitgcm-0.4.1-py_0.tar.bz2#af0a895f68c080a12e019162487b8aeb
 https://conda.anaconda.org/conda-forge/noarch/xrft-0.2.2-pyh9f0ad1d_0.tar.bz2#8aecf1d99b3335aecd6eb6b8e7169da1
-https://conda.anaconda.org/conda-forge/linux-64/awscli-1.18.164-py38h32f6830_0.tar.bz2#f10f8f42e5921c52d3fa7db4dcea95af
-https://conda.anaconda.org/conda-forge/noarch/boto3-1.16.4-pyh9f0ad1d_0.tar.bz2#25149194af6495c37bc60a94db6864b6
+https://conda.anaconda.org/conda-forge/linux-64/awscli-1.18.165-py38h32f6830_0.tar.bz2#58b940d3c574edfa51e09791a4e50a03
+https://conda.anaconda.org/conda-forge/noarch/boto3-1.16.5-pyh9f0ad1d_0.tar.bz2#10ff3efc6060b7a6fa3b9f02d1024dc1
 https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.18.0-py38h4f3c6b6_2.tar.bz2#03a6f2145cf68c7d71ec0fd76b0e4928
 https://conda.anaconda.org/conda-forge/noarch/colorcet-2.0.1-py_0.tar.bz2#aa65c1760b4ccc79d3be1fb3a7060de8
 https://conda.anaconda.org/conda-forge/noarch/dask-ml-1.7.0-py_0.tar.bz2#ffc9eea86e065cd464f6a141dda50127
@@ -474,7 +475,7 @@ https://conda.anaconda.org/conda-forge/noarch/intake-esm-2020.8.15-py_0.tar.bz2#
 https://conda.anaconda.org/conda-forge/noarch/intake-geopandas-0.2.3-py_0.tar.bz2#54343707274454ec1f9ecd1538cbe5a4
 https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.4.0-py_0.tar.bz2#657133ce00e16fccd07e789ad4f92aea
 https://conda.anaconda.org/conda-forge/linux-64/ipykernel-5.3.4-py38h1cdfbd6_1.tar.bz2#2b31fc793aa78f0572bba6ee24e81358
-https://conda.anaconda.org/conda-forge/noarch/panel-0.9.7-py_0.tar.bz2#b5147a3905e3984233a7e29f690b50db
+https://conda.anaconda.org/conda-forge/noarch/panel-0.10.0-py_0.tar.bz2#75b25f0347a90e54b243391bc22898a3
 https://conda.anaconda.org/conda-forge/noarch/prefect-0.13.11-py_0.tar.bz2#aa6c815bfae2b43dc68076a8871da039
 https://conda.anaconda.org/conda-forge/linux-64/pydap-3.2.2-py38_1000.tar.bz2#076fc728a3a3a5b5af594a9a65f5484e
 https://conda.anaconda.org/conda-forge/noarch/python-kubernetes-12.0.0-pyh9f0ad1d_0.tar.bz2#29fbe952d848de74819fb012de2525ba

--- a/pangeo-notebook/environment.yml
+++ b/pangeo-notebook/environment.yml
@@ -15,6 +15,7 @@ dependencies:
  - datashader
  - descartes
  - eofs
+ - erddapy
  - esmpy
  - fastjmd95
  - fsspec

--- a/pangeo-notebook/packages.txt
+++ b/pangeo-notebook/packages.txt
@@ -5,7 +5,7 @@ abseil-cpp-20200225.2
 adal-1.2.5
 affine-2.3.0
 aiofiles-0.5.0
-aiohttp-3.7.1
+aiohttp-3.7.2
 alabaster-0.7.12
 alembic-1.4.3
 aniso8601-7.0.0
@@ -24,7 +24,7 @@ aws-c-common-0.4.59
 aws-c-event-stream-0.1.6
 aws-checksums-0.1.9
 aws-sdk-cpp-1.8.70
-awscli-1.18.164
+awscli-1.18.165
 babel-2.8.0
 backcall-0.2.0
 backports-1.0
@@ -35,8 +35,8 @@ blinker-1.4
 blosc-1.20.1
 bokeh-2.2.3
 boost-cpp-1.72.0
-boto3-1.16.4
-botocore-1.19.4
+boto3-1.16.5
+botocore-1.19.5
 bottleneck-1.3.2
 branca-0.3.1
 brotli-1.0.9
@@ -94,6 +94,7 @@ docutils-0.15.2
 eccodes-2.19.0
 entrypoints-0.3
 eofs-1.4.0
+erddapy-0.7.2
 esmf-8.0.1
 esmpy-8.0.1
 expat-2.2.9
@@ -307,7 +308,7 @@ pamela-1.0.0
 pandas-1.1.3
 pandoc-2.11.0.4
 pandocfilters-1.4.2
-panel-0.9.7
+panel-0.10.0
 pangeo-dask-2020.10.08
 pangeo-notebook-2020.10.08
 pango-1.42.4


### PR DESCRIPTION
erddapy is a lightweight package to help interact with the [ERDDAP RESTful API](https://coastwatch.pfeg.noaa.gov/erddap/rest.html#requests), commonly used for environmental sensor data.

erddapy only depends on pytz and requests, both already in the environment. 