### PR TITLE
Bump base image to Ubuntu 20.04

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 # Master build file for pangeo images
 
 # Run this section as root


### PR DESCRIPTION
New LTS that's been out for a while. The most relavant
feature here is support for R 4.0, which traditionally
brings base R from the debian package. All prebuilt libraries
from https://packagemanager.rstudio.com/client/#/repos/1/packages
are built against focal for R 4.0 - so it becomes quite
difficult to use prebuilt R packages with 4.0 on bionic.