### PR TITLE
add /test slash command to re-run ci

### DIFF
--- a/.github/workflows/ChatOpsDispatcher.yml
+++ b/.github/workflows/ChatOpsDispatcher.yml
@@ -18,5 +18,10 @@ jobs:
                 "command": "condalock",
                 "permission": "none",
                 "issue_type": "pull-request"
+              },
+              {
+                "command": "test",
+                "permission": "none",
+                "issue_type": "pull-request"
               }
             ]

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -2,6 +2,8 @@
 name: Test
 
 on:
+  repository_dispatch:
+    types: [test]
   pull_request:
     types: [synchronize]
 


### PR DESCRIPTION
sometimes you want to manually trigger the Test workflow from a PR comment (https://github.com/pangeo-data/pangeo-docker-images/pull/156) 

This allows you to add `/test` as the first line of a comment to re-run CI