### PR TITLE
fix for test slash command

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -3,7 +3,7 @@ name: Test
 
 on:
   repository_dispatch:
-    types: [test]
+    types: [test-command]
   pull_request:
     types: [synchronize]
 


### PR DESCRIPTION
was missing the `-command` suffix for repository dispatch type: 
```
# Any PR opened, build images and run tests
name: Test

on:
  repository_dispatch:
    types: [test-command]
```