### PR TITLE
fix test workflow checkout

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.PANGEOBOT_TOKEN }}
+        # These lines are critical, otherwise it seems slash commands run against master branch
+        repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
     - name: Build Base Image
       run: |


### PR DESCRIPTION
another follow up to https://github.com/pangeo-data/pangeo-docker-images/pull/157. not sure if this will work, it can get confusing to know against which commit and branch slash commands are running. might be better to break into completely separate .yml files...