### PR TITLE
Let base-image recognize jupyter_notebook_config.py, and configure nb_conda_kernels to not register a kernel again

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -134,4 +134,16 @@ ONBUILD RUN echo "Checking for 'start'..." \
         chmod +x start \
         && cp start /srv/start \
         ; fi
+
+# Copy jupyter_notebook_config.py to /etc/jupyter, which is an action not done
+# with repo2docker.
+ONBUILD USER root
+ONBUILD RUN echo "Checking for config 'jupyter_notebook_config.py'..." \
+        ; [ -d binder ] && cd binder \
+        ; [ -d .binder ] && cd .binder \
+        ; if test -f "jupyter_notebook_config.py" ; then \
+        mkdir -p /etc/jupyter \
+        && cp jupyter_notebook_config.py /etc/jupyter \
+        ; fi
+ONBUILD USER ${NB_USER}
 # ----------------------

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -59,7 +59,8 @@ ENTRYPOINT ["/srv/start"]
 # Only run these if used as a base image
 # ----------------------
 ONBUILD USER root
-# hardcode for now
+# FIXME (?): user and home folder is hardcoded for now
+# FIXME (?): this line breaks the cache of all steps below
 ONBUILD COPY --chown=jovyan:jovyan . /home/jovyan
 
 ONBUILD RUN echo "Checking for 'binder' or '.binder' subfolder" \
@@ -80,6 +81,15 @@ ONBUILD RUN echo "Checking for 'apt.txt'..." \
         && xargs -a apt.txt apt-get install -y \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \
+        ; fi
+
+# Copy jupyter_notebook_config.py to /etc/jupyter
+ONBUILD RUN echo "Checking for 'jupyter_notebook_config.py'..." \
+        ; [ -d binder ] && cd binder \
+        ; [ -d .binder ] && cd .binder \
+        ; if test -f "jupyter_notebook_config.py" ; then \
+        mkdir -p /etc/jupyter \
+        && cp jupyter_notebook_config.py /etc/jupyter \
         ; fi
 
 ONBUILD USER ${NB_USER}
@@ -134,16 +144,4 @@ ONBUILD RUN echo "Checking for 'start'..." \
         chmod +x start \
         && cp start /srv/start \
         ; fi
-
-# Copy jupyter_notebook_config.py to /etc/jupyter, which is an action not done
-# with repo2docker.
-ONBUILD USER root
-ONBUILD RUN echo "Checking for config 'jupyter_notebook_config.py'..." \
-        ; [ -d binder ] && cd binder \
-        ; [ -d .binder ] && cd .binder \
-        ; if test -f "jupyter_notebook_config.py" ; then \
-        mkdir -p /etc/jupyter \
-        && cp jupyter_notebook_config.py /etc/jupyter \
-        ; fi
-ONBUILD USER ${NB_USER}
 # ----------------------

--- a/ml-notebook/jupyter_notebook_config.py
+++ b/ml-notebook/jupyter_notebook_config.py
@@ -1,0 +1,5 @@
+import os
+
+# Configure nb_conda_kernels to avoid registering jupyter kernels in our conda
+# environment again.
+c.CondaKernelSpecManager.env_filter = f'.*envs/{os.environ["CONDA_ENV"]}.*'

--- a/pangeo-notebook/jupyter_notebook_config.py
+++ b/pangeo-notebook/jupyter_notebook_config.py
@@ -1,0 +1,5 @@
+import os
+
+# Configure nb_conda_kernels to avoid registering jupyter kernels in our conda
+# environment again.
+c.CondaKernelSpecManager.env_filter = f'.*envs/{os.environ["CONDA_ENV"]}.*'


### PR DESCRIPTION
## PR summary

This PR solves the issue below. It does so in two steps.
1. Adds the feature base-image feature to detects a `jupyter_notebook_config.py` file and injects it to the otherwise empty folder `/etc/jupyter`.
2. It adds a `jupyter_notebook_config.py` file to the `pangeo-notebook` and `ml-notebook` folder that have `nb_conda_kernels` and configures it to avoid register a jupyter kernel twice.

## Duplicated kernel registration issue

The pangeo-notebook and ml-notebook install nb_conda_kernels, which will scan conda environments and register jupyter kernels based on installed packages in those kernels. But, if a kernel is already registered it will be registered again.

![image](https://user-images.githubusercontent.com/3837114/111597950-ffd39080-87ce-11eb-9ec8-61869bc2f12d.png)

This can be avoided though, if we for example have a `/etc/jupyter/jupyter_notebook_config.py` available like this...

```python
import os

# Configure nb_conda_kernels to avoid registering jupyter kernels in our conda
# environment again.
c.CondaKernelSpecManager.env_filter = f'.*envs/{os.environ["CONDA_ENV"]}.*'
```

![image](https://user-images.githubusercontent.com/3837114/111597165-35c44500-87ce-11eb-9ef6-3ca9a43d8476.png)