### PR TITLE
add stackstac in pip requirements.txt

### DIFF
--- a/base-notebook/conda-linux-64.lock
+++ b/base-notebook/conda-linux-64.lock
@@ -80,7 +80,7 @@ https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.8-1_cp38.tar.bz2#8d
 https://conda.anaconda.org/conda-forge/noarch/pytz-2021.1-pyhd8ed1ab_0.tar.bz2#3af2e9424d5eb0063824a3f9b850d411
 https://conda.anaconda.org/conda-forge/noarch/send2trash-1.5.0-py_0.tar.bz2#c3779037a635e1150f1c53c28b875949
 https://conda.anaconda.org/conda-forge/noarch/simpervisor-0.4-pyhd8ed1ab_0.tar.bz2#12b5f0d11cc26bf386bd9a2f99099648
-https://conda.anaconda.org/conda-forge/noarch/six-1.15.0-pyh9f0ad1d_0.tar.bz2#1eec421f0f1f39e579e44e4a5ce646a2
+https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2#e5f25f8dbc060e9a8d912e432202afc2
 https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.3.0-pyhd8ed1ab_0.tar.bz2#2f5b87cd0bdf1822b62e40909f471db4
 https://conda.anaconda.org/conda-forge/noarch/tblib-1.7.0-pyhd8ed1ab_0.tar.bz2#3d4afc31302aa7be471feb6be048ed76
 https://conda.anaconda.org/conda-forge/noarch/testpath-0.4.4-py_0.tar.bz2#3b98fff4d5342bebde2ecaa314f796f9
@@ -138,7 +138,7 @@ https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-1.4.13-py38h497a2fe_0
 https://conda.anaconda.org/conda-forge/linux-64/terminado-0.9.4-py38h578d9bd_0.tar.bz2#bc644cbe521455667e0f0690147dbe48
 https://conda.anaconda.org/conda-forge/linux-64/yarl-1.6.3-py38h497a2fe_1.tar.bz2#c5726a316ae938293c35bc0a9c84093c
 https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.7.4-py38h497a2fe_0.tar.bz2#e95a206e5f3dc6833e5b7870819a21e6
-https://conda.anaconda.org/conda-forge/noarch/alembic-1.5.8-pyhd8ed1ab_0.tar.bz2#e96488635ba0005f9c977fc9c46bb6c3
+https://conda.anaconda.org/conda-forge/noarch/alembic-1.6.0-pyhd8ed1ab_1.tar.bz2#31cf954ad89f591af322e4adf7a08371
 https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2#c5b3edc62d6309088f4970b3eaaa65a6
 https://conda.anaconda.org/conda-forge/noarch/bleach-3.3.0-pyh44b312d_0.tar.bz2#abf6b76c39358ca36ca706c46f054f2a
 https://conda.anaconda.org/conda-forge/linux-64/distributed-2021.4.1-py38h578d9bd_0.tar.bz2#8aa81a9e95fbd6adf9b0054e7d1acbce

--- a/base-notebook/packages.txt
+++ b/base-notebook/packages.txt
@@ -2,7 +2,7 @@ _libgcc_mutex-0.1
 _openmp_mutex-4.5
 adal-1.2.7
 aiohttp-3.7.4
-alembic-1.5.8
+alembic-1.6.0
 anyio-2.2.0
 argon2-cffi-20.1.0
 async-timeout-3.0.1
@@ -154,7 +154,7 @@ ruamel.yaml.clib-0.2.2
 send2trash-1.5.0
 setuptools-49.6.0
 simpervisor-0.4
-six-1.15.0
+six-1.16.0
 sniffio-1.2.0
 sortedcontainers-2.3.0
 sqlalchemy-1.4.13

--- a/ml-notebook/conda-linux-64.lock
+++ b/ml-notebook/conda-linux-64.lock
@@ -156,7 +156,7 @@ https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.8-1_cp38.tar.bz2#8d
 https://conda.anaconda.org/conda-forge/noarch/pytz-2021.1-pyhd8ed1ab_0.tar.bz2#3af2e9424d5eb0063824a3f9b850d411
 https://conda.anaconda.org/conda-forge/noarch/send2trash-1.5.0-py_0.tar.bz2#c3779037a635e1150f1c53c28b875949
 https://conda.anaconda.org/conda-forge/noarch/simpervisor-0.4-pyhd8ed1ab_0.tar.bz2#12b5f0d11cc26bf386bd9a2f99099648
-https://conda.anaconda.org/conda-forge/noarch/six-1.15.0-pyh9f0ad1d_0.tar.bz2#1eec421f0f1f39e579e44e4a5ce646a2
+https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2#e5f25f8dbc060e9a8d912e432202afc2
 https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.3.0-pyhd8ed1ab_0.tar.bz2#2f5b87cd0bdf1822b62e40909f471db4
 https://conda.anaconda.org/conda-forge/noarch/tblib-1.7.0-pyhd8ed1ab_0.tar.bz2#3d4afc31302aa7be471feb6be048ed76
 https://conda.anaconda.org/conda-forge/noarch/tensorboard-plugin-wit-1.8.0-pyh44b312d_0.tar.bz2#2b9cacb9dfeb456540e5e8627a2bcd4e
@@ -258,7 +258,7 @@ https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-1.4.13-py38h497a2fe_0
 https://conda.anaconda.org/conda-forge/linux-64/terminado-0.9.4-py38h578d9bd_0.tar.bz2#bc644cbe521455667e0f0690147dbe48
 https://conda.anaconda.org/conda-forge/linux-64/yarl-1.6.3-py38h497a2fe_1.tar.bz2#c5726a316ae938293c35bc0a9c84093c
 https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.7.4-py38h497a2fe_0.tar.bz2#e95a206e5f3dc6833e5b7870819a21e6
-https://conda.anaconda.org/conda-forge/noarch/alembic-1.5.8-pyhd8ed1ab_0.tar.bz2#e96488635ba0005f9c977fc9c46bb6c3
+https://conda.anaconda.org/conda-forge/noarch/alembic-1.6.0-pyhd8ed1ab_1.tar.bz2#31cf954ad89f591af322e4adf7a08371
 https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2#c5b3edc62d6309088f4970b3eaaa65a6
 https://conda.anaconda.org/conda-forge/noarch/bleach-3.3.0-pyh44b312d_0.tar.bz2#abf6b76c39358ca36ca706c46f054f2a
 https://conda.anaconda.org/conda-forge/linux-64/cupy-9.0.0-py38ha69542f_1.tar.bz2#a19c9981cd40e53f61fd7dccd63a80e7
@@ -289,7 +289,7 @@ https://conda.anaconda.org/conda-forge/noarch/tifffile-2021.4.8-pyhd8ed1ab_0.tar
 https://conda.anaconda.org/conda-forge/noarch/xarray-0.17.0-pyhd8ed1ab_0.tar.bz2#972b41b5afded8acbfed8ea18d016765
 https://conda.anaconda.org/conda-forge/noarch/zarr-2.8.1-pyhd8ed1ab_0.tar.bz2#824dfe3d0672623823eddd30f197db84
 https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.3.1-py38h578d9bd_0.tar.bz2#1895246899394e17007e425fe300aec4
-https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.19.0-py38hc9c980b_0.tar.bz2#8024c0f96cc8337f5148a07d4e1a8e13
+https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.19.0.post1-py38hc9c980b_0.tar.bz2#65e97172e139d3465895eb07a1fd52f2
 https://conda.anaconda.org/conda-forge/noarch/certipy-0.1.3-py_0.tar.bz2#23486713ef5712923e7c57cae609b22e
 https://conda.anaconda.org/conda-forge/linux-64/fiona-1.8.18-py38h58f84aa_1.tar.bz2#47bd73be08703428b4233a568569ee8c
 https://conda.anaconda.org/conda-forge/noarch/google-auth-1.30.0-pyh44b312d_0.tar.bz2#6bfc2b6ab5e47c4e57355e511fab4bfb

--- a/ml-notebook/packages.txt
+++ b/ml-notebook/packages.txt
@@ -9,7 +9,7 @@ affine-2.3.0
 aiobotocore-1.3.0
 aiohttp-3.7.4
 aioitertools-0.7.1
-alembic-1.5.8
+alembic-1.6.0
 anyio-2.2.0
 appdirs-1.4.4
 argon2-cffi-20.1.0
@@ -41,7 +41,7 @@ c-ares-1.17.1
 ca-certificates-2020.12.5
 cachetools-4.2.2
 cairo-1.16.0
-cartopy-0.19.0
+cartopy-0.19.0.post1
 certifi-2020.12.5
 certipy-0.1.3
 cffi-1.14.5
@@ -295,7 +295,7 @@ send2trash-1.5.0
 setuptools-49.6.0
 shapely-1.7.1
 simpervisor-0.4
-six-1.15.0
+six-1.16.0
 snappy-1.1.8
 sniffio-1.2.0
 snuggs-1.4.7

--- a/pangeo-notebook/conda-linux-64.lock
+++ b/pangeo-notebook/conda-linux-64.lock
@@ -30,7 +30,7 @@ https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.35-h67ddf6f_
 https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-9.3.0-h2828fa1_19.tar.bz2#9d5cdfc51476ee4dcdd96ed2dca3f943
 https://conda.anaconda.org/conda-forge/linux-64/abseil-cpp-20210324.0-h9c3ff4c_0.tar.bz2#bf9b65d81c0f9568452ee280fe1b0100
 https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.3-h516909a_0.tar.bz2#1378b88874f42ac31b2f8e4f6975cb7b
-https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.5.8-h7f98852_0.tar.bz2#ec2f5c203709aa5a184f64ec3c114a10
+https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.5.10-h7f98852_0.tar.bz2#eadf152033ba2d9fa60f137045b5b64d
 https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.0-h9c3ff4c_0.tar.bz2#5e815e5126c6f7e34ab4496fa1b48dca
 https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h9c3ff4c_4.tar.bz2#f4f75dc7038aaeb6eaae16a5ef5350b3
 https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2#a1fd65c7ccbf10880423d82bca54eb54
@@ -91,8 +91,8 @@ https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.5-h516909a_1.tar.bz2#33f6
 https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h516909a_0.tar.bz2#03a530e925414902547cf48da7756db8
 https://conda.anaconda.org/conda-forge/linux-64/zfp-0.5.5-h9c3ff4c_5.tar.bz2#a48a43fdc002f68cbc17b44681a02d42
 https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.11-h516909a_1010.tar.bz2#339cc5584e6d26bc73a875ba900028c3
-https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.4.5-h5ca8eb3_9.tar.bz2#b1511fcacd9a8101456db9bde927c034
-https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.11-hdc257ea_4.tar.bz2#1685b3e5c71a62a25360f0d1ff3eab7b
+https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.5.6-hd8e7a0d_1.tar.bz2#0dccf17e65def79a4537c0df5a706dc9
+https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.11-h8a473d3_5.tar.bz2#8df54d3beb0453934d1417b87bdc4bb5
 https://conda.anaconda.org/conda-forge/linux-64/brunsli-0.1-h9c3ff4c_0.tar.bz2#c1ac6229d0bfd14f8354ff9ad2a26cad
 https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-9.3.0-hf25ea35_30.tar.bz2#08898db641edb79224abbda430dcb229
 https://conda.anaconda.org/conda-forge/linux-64/gettext-0.19.8.1-h0b5b191_1005.tar.bz2#ff6f69b593a9e74c0e6b61908ac513fa
@@ -121,7 +121,7 @@ https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.3-h9d8b166_2.tar.bz
 https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.3-hd9c2040_1000.tar.bz2#9e856f78d5c80d5a78f61e72d1d473a3
 https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.4-h9c3ff4c_0.tar.bz2#9105c7da67ebfb39ff08e2a8ea72bb71
 https://conda.anaconda.org/conda-forge/linux-64/zstd-1.4.9-ha95c52a_0.tar.bz2#b481dc9fda3af2a681d08a4d5cd1ea0b
-https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.9.4-hfee9f7d_5.tar.bz2#f097c1b7ec10ee1085d6ff0d3aeb4805
+https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.9.11-hd6868ff_1.tar.bz2#ea037f7a8aea0f39c25a05ff80e376c9
 https://conda.anaconda.org/conda-forge/linux-64/boost-cpp-1.74.0-hc6e9bd1_2.tar.bz2#eca3e3674bf1f00fcddd63e6668fd9dd
 https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.4-h0708190_1.tar.bz2#4a06f2ac2e5bfae7b6b245171c3f07aa
 https://conda.anaconda.org/conda-forge/linux-64/grpc-cpp-1.37.1-h36de60a_0.tar.bz2#a9d669b01509c9265a2be17394215d15
@@ -139,7 +139,7 @@ https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.35.5-h74cdb3f_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.2.8-h91fcb0e_0.tar.bz2#a254b127bf755a6039cf29457c82d9d6
 https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.7.0-h7f98852_0.tar.bz2#0cd07abd75b2fad023161c657524ddbd
 https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.36.0-h3371d22_4.tar.bz2#661e1ed5d92552785d9f8c781ce68685
-https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.2.7-h832d4c5_2.tar.bz2#bdfb3207f4309156946c13605415b79a
+https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.2.7-he3525c2_3.tar.bz2#fcaea61128a16d359637617c53ac78b3
 https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-4.3.1-hca11adc_2.tar.bz2#94b778570f9a32e630701de15e9c7abb
 https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.13.1-hba837de_1005.tar.bz2#fd3611672eb91bc9d24fd6fb970037eb
 https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.6-h04a7f16_0.tar.bz2#b24a1e18325a6e8f8b6b4a2ec5860ce2
@@ -163,7 +163,7 @@ https://conda.anaconda.org/conda-forge/noarch/asn1crypto-1.4.0-pyh9f0ad1d_0.tar.
 https://conda.anaconda.org/conda-forge/noarch/async-timeout-3.0.1-py_1000.tar.bz2#8b11024b2762a07aaa07d2743231a41b
 https://conda.anaconda.org/conda-forge/noarch/async_generator-1.10-py_0.tar.bz2#d56c596e61b1c4952acf0a9920856c12
 https://conda.anaconda.org/conda-forge/noarch/attrs-20.3.0-pyhd3deb0d_0.tar.bz2#5b319abb055eefcfa344bc21378ca23f
-https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.8.151-h973185b_2.tar.bz2#c389f0cf7154af909160868ddc40441e
+https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.8.186-h2f913a8_1.tar.bz2#01b8903a35c58f4b8d932f28506dfa94
 https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2#6006a6d08a3fa99268a2681c7fb55213
 https://conda.anaconda.org/conda-forge/noarch/backports-1.0-py_2.tar.bz2#0da16b293affa6ac31812376f8eb79dd
 https://conda.anaconda.org/conda-forge/noarch/blinker-1.4-py_1.tar.bz2#fa509a09190583f869ae442bf4d17f5f
@@ -223,7 +223,7 @@ https://conda.anaconda.org/conda-forge/noarch/pytzdata-2020.1-pyh9f0ad1d_0.tar.b
 https://conda.anaconda.org/conda-forge/noarch/redis-py-3.5.3-pyh9f0ad1d_0.tar.bz2#bf8e5880a103e0b243a9531874080439
 https://conda.anaconda.org/conda-forge/noarch/send2trash-1.5.0-py_0.tar.bz2#c3779037a635e1150f1c53c28b875949
 https://conda.anaconda.org/conda-forge/noarch/simpervisor-0.4-pyhd8ed1ab_0.tar.bz2#12b5f0d11cc26bf386bd9a2f99099648
-https://conda.anaconda.org/conda-forge/noarch/six-1.15.0-pyh9f0ad1d_0.tar.bz2#1eec421f0f1f39e579e44e4a5ce646a2
+https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2#e5f25f8dbc060e9a8d912e432202afc2
 https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.3.0-pyhd8ed1ab_0.tar.bz2#2f5b87cd0bdf1822b62e40909f471db4
 https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.0.1-py_1.tar.bz2#aa1db70848c19bace567ba39a157f508
 https://conda.anaconda.org/conda-forge/noarch/starlette-base-0.13.6-py_0.tar.bz2#4048417a60cd022ce5c1badb0a2e11dd
@@ -263,12 +263,12 @@ https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.11.0-py38h497a2fe_3.ta
 https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h48d8840_2.tar.bz2#eba672c69baf366fdedd1c6f702dbb81
 https://conda.anaconda.org/conda-forge/noarch/docker-pycreds-0.4.0-py_0.tar.bz2#c69f19038efee4eb534623610d0c2053
 https://conda.anaconda.org/conda-forge/noarch/docrep-0.2.7-py_0.tar.bz2#7a8411a58c16dffe32424251e62e3149
-https://conda.anaconda.org/conda-forge/linux-64/docutils-0.15.2-py38h578d9bd_1.tar.bz2#5616c3bde2d113a4d2b2d90145df5dd0
+https://conda.anaconda.org/conda-forge/linux-64/docutils-0.15.2-py38h578d9bd_2.tar.bz2#a62e348e72a6122a17d2146d8c5eb4e1
 https://conda.anaconda.org/conda-forge/noarch/fasteners-0.14.1-py_3.tar.bz2#8af0bf3cfe806fb001d9923b4fe1594b
 https://conda.anaconda.org/conda-forge/linux-64/future-0.18.2-py38h578d9bd_3.tar.bz2#73014e11488f0c0c7f18a3817734d955
 https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.6.0-h2b14fbe_4.tar.bz2#95731212a74717b0368f9805513f6da7
 https://conda.anaconda.org/conda-forge/linux-64/greenlet-1.0.0-py38h709712a_0.tar.bz2#e44c3b2a786894f584b03b0dc5ad3b13
-https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-2.8.0-h83ec7ef_1.tar.bz2#0b20d7ac5b7beec9615f35ab88c161f8
+https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-2.8.1-h83ec7ef_0.tar.bz2#654935b08e8bd4a8cbf6a4253e290c04
 https://conda.anaconda.org/conda-forge/linux-64/httptools-0.1.1-py38h497a2fe_2.tar.bz2#00be6cb2bc13757a3f1e950806d72108
 https://conda.anaconda.org/conda-forge/linux-64/importlib-metadata-4.0.1-py38h578d9bd_0.tar.bz2#df6fae32b464e9fb5010c4784ce2efb0
 https://conda.anaconda.org/conda-forge/linux-64/importlib_resources-5.1.2-py38h578d9bd_0.tar.bz2#86e3d225a89a81d6859e76e1700c4496
@@ -312,6 +312,7 @@ https://conda.anaconda.org/conda-forge/noarch/python-utils-2.5.6-pyh44b312d_0.ta
 https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-2.0.1-pyhd3deb0d_0.tar.bz2#12e4d3289ffcbdf465864af6eb2c6f4b
 https://conda.anaconda.org/conda-forge/linux-64/pyyaml-5.4.1-py38h497a2fe_0.tar.bz2#36d6e06148013694eb943576cd305f67
 https://conda.anaconda.org/conda-forge/linux-64/pyzmq-22.0.3-py38h2035c66_1.tar.bz2#cb624b5ab0fee319a6b97a94850130e5
+https://conda.anaconda.org/conda-forge/noarch/retrying-1.3.3-py_2.tar.bz2#a11f356d6f93b74b4a84e9501afd48b4
 https://conda.anaconda.org/conda-forge/noarch/rsa-4.7.2-pyh44b312d_0.tar.bz2#3452ab3790dbb1df9508b3fa4ea2f806
 https://conda.anaconda.org/conda-forge/linux-64/rtree-0.9.7-py38h02d302b_1.tar.bz2#25f9aed49cf82480e85967bb5db18408
 https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.2-py38h497a2fe_2.tar.bz2#5637db1362aff1866921cfcd558065ab
@@ -328,7 +329,7 @@ https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.12.1-py38h497a2fe_3.tar.
 https://conda.anaconda.org/conda-forge/noarch/zict-2.0.0-py_0.tar.bz2#4750152be22f24d695b3004c5e1712d3
 https://conda.anaconda.org/conda-forge/linux-64/anyio-2.2.0-py38h578d9bd_0.tar.bz2#8c1552d357e82fb15ec7e017e7f74cc7
 https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-20.1.0-py38h497a2fe_2.tar.bz2#254bc9d931e9891ce1068eb0335700c1
-https://conda.anaconda.org/conda-forge/linux-64/arrow-cpp-4.0.0-py38hd6878d3_0_cpu.tar.bz2#e99ad14b0204d2d60958cd90ec82ea1d
+https://conda.anaconda.org/conda-forge/linux-64/arrow-cpp-4.0.0-py38ha12db41_1_cpu.tar.bz2#236acacff1679d90bf35bb0e02cd9d58
 https://conda.anaconda.org/conda-forge/linux-64/av-8.0.3-py38hcaf3a0b_0.tar.bz2#1cfa3840eb115bf5a382bc9fde62517d
 https://conda.anaconda.org/conda-forge/linux-64/bottleneck-1.3.2-py38h5c078b8_3.tar.bz2#89e4ec22a0d45c6e8f5219170d548418
 https://conda.anaconda.org/conda-forge/linux-64/brotlipy-0.7.0-py38h497a2fe_1001.tar.bz2#56753dd777a6517b34966ddcb39af734
@@ -381,7 +382,7 @@ https://conda.anaconda.org/conda-forge/noarch/traittypes-0.2.1-pyh9f0ad1d_2.tar.
 https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.13.4-py38h578d9bd_0.tar.bz2#de1a3d343faa47c017ccc30c4e978dc8
 https://conda.anaconda.org/conda-forge/linux-64/yarl-1.6.3-py38h497a2fe_1.tar.bz2#c5726a316ae938293c35bc0a9c84093c
 https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.7.4-py38h497a2fe_0.tar.bz2#e95a206e5f3dc6833e5b7870819a21e6
-https://conda.anaconda.org/conda-forge/noarch/alembic-1.5.8-pyhd8ed1ab_0.tar.bz2#e96488635ba0005f9c977fc9c46bb6c3
+https://conda.anaconda.org/conda-forge/noarch/alembic-1.6.0-pyhd8ed1ab_1.tar.bz2#31cf954ad89f591af322e4adf7a08371
 https://conda.anaconda.org/conda-forge/linux-64/astropy-4.2.1-py38h497a2fe_0.tar.bz2#6571609aec2e8ecbcd8785a70177b968
 https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2#c5b3edc62d6309088f4970b3eaaa65a6
 https://conda.anaconda.org/conda-forge/noarch/bleach-3.3.0-pyh44b312d_0.tar.bz2#abf6b76c39358ca36ca706c46f054f2a
@@ -423,7 +424,7 @@ https://conda.anaconda.org/conda-forge/noarch/zarr-2.8.1-pyhd8ed1ab_0.tar.bz2#82
 https://conda.anaconda.org/conda-forge/linux-64/bcrypt-3.2.0-py38h497a2fe_1.tar.bz2#80332716d56bcf147fecda0fa4b6c109
 https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.3.1-py38h578d9bd_0.tar.bz2#1895246899394e17007e425fe300aec4
 https://conda.anaconda.org/conda-forge/noarch/branca-0.4.2-pyhd8ed1ab_0.tar.bz2#836c975d3ae4f21c3cd047c10b15a7cf
-https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.19.0-py38hc9c980b_0.tar.bz2#8024c0f96cc8337f5148a07d4e1a8e13
+https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.19.0.post1-py38hc9c980b_0.tar.bz2#65e97172e139d3465895eb07a1fd52f2
 https://conda.anaconda.org/conda-forge/noarch/certipy-0.1.3-py_0.tar.bz2#23486713ef5712923e7c57cae609b22e
 https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.5.1-pyh44b312d_0.tar.bz2#fe258d69bcdcaba1aa1c8fb5ae2965ba
 https://conda.anaconda.org/conda-forge/noarch/cfgrib-0.9.9.0-pyhd8ed1ab_1.tar.bz2#6d15ea440b120f2157aa9b05e8b152e7
@@ -440,7 +441,7 @@ https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad
 https://conda.anaconda.org/conda-forge/linux-64/nb_conda_kernels-2.3.1-py38h578d9bd_0.tar.bz2#5ecb1e39acb8bc7d3e4c0340b247754e
 https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.3-pyhd8ed1ab_0.tar.bz2#bafa5df6d4f8db69a4d197b4657127e7
 https://conda.anaconda.org/conda-forge/noarch/nc-time-axis-1.2.0-py_1.tar.bz2#f3158a5d335f0f44f09cf05d3fb4107e
-https://conda.anaconda.org/conda-forge/linux-64/pyarrow-4.0.0-py38hc9229eb_0_cpu.tar.bz2#f4882789bf136449ac9e15a7c3dcd917
+https://conda.anaconda.org/conda-forge/linux-64/pyarrow-4.0.0-py38hc9229eb_1_cpu.tar.bz2#6fc8aefb088cfb898d201e75b9727381
 https://conda.anaconda.org/conda-forge/linux-64/pyqtchart-5.12-py38h7400c14_7.tar.bz2#3003444b4f41742a33b7afdeb3260cbc
 https://conda.anaconda.org/conda-forge/linux-64/pyqtwebengine-5.12.1-py38h7400c14_7.tar.bz2#1c17944e118b314ff4d0bfc05f03a5e1
 https://conda.anaconda.org/conda-forge/noarch/python-box-5.3.0-pyhd8ed1ab_0.tar.bz2#058df6cda33c589030b15ee93a784a82
@@ -488,6 +489,7 @@ https://conda.anaconda.org/conda-forge/noarch/rechunker-0.4.2-pyhd8ed1ab_0.tar.b
 https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.3.0-pyh9f0ad1d_0.tar.bz2#acdcfb3267ef1a8e576e84480a5e259d
 https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.3.7-pyhd8ed1ab_0.tar.bz2#da54f21dfcc13706e1c2c07fc441ce3d
 https://conda.anaconda.org/conda-forge/noarch/sat-stac-0.4.1-pyh44b312d_0.tar.bz2#db4efed11f9ee2b921d2893fc66806f2
+https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.3.6-pyhd8ed1ab_0.tar.bz2#45ffebcf5b670636d2d0b702f758144f
 https://conda.anaconda.org/conda-forge/noarch/sshtunnel-0.3.1-pyhd8ed1ab_0.tar.bz2#ff01e34ff99d488b6ad8c63e6b0a72c3
 https://conda.anaconda.org/conda-forge/noarch/trollimage-1.15.0-pyhd8ed1ab_0.tar.bz2#2cddbfbc34c453e5969d6bf7d50685eb
 https://conda.anaconda.org/conda-forge/linux-64/xcape-0.1.2-py38he1ac83b_2.tar.bz2#eded43c36cad68c58751e698e194c11e
@@ -541,7 +543,7 @@ https://conda.anaconda.org/conda-forge/noarch/nbclassic-0.2.7-pyhd8ed1ab_0.tar.b
 https://conda.anaconda.org/conda-forge/noarch/nbgitpuller-0.9.0-py_0.tar.bz2#ce05504b25f7e0234c99e7ef1f746cbd
 https://conda.anaconda.org/conda-forge/noarch/pangeo-dask-2021.04.26-hd8ed1ab_0.tar.bz2#df972a069e80d9f137c5476e45c66523
 https://conda.anaconda.org/conda-forge/linux-64/widgetsnbextension-3.5.1-py38h578d9bd_4.tar.bz2#beb8a105545382ba138c81c926289b5b
-https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.1.8-pyhd8ed1ab_0.tar.bz2#8c10a5bdd9fa71979a9631d05a4ba7dd
+https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.2.0-pyhd8ed1ab_0.tar.bz2#444832c34927bad568740312234e5f22
 https://conda.anaconda.org/conda-forge/noarch/geocube-0.0.16-pyhd8ed1ab_0.tar.bz2#33591a4756559f238f347ad0ce859b85
 https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.9.1-pyha770c72_0.tar.bz2#2b6b08ce5c64d1661f9a69af0622e778
 https://conda.anaconda.org/conda-forge/noarch/hvplot-0.7.1-pyh44b312d_0.tar.bz2#440851c33f336e5a6eb107120946869a

--- a/pangeo-notebook/environment.yml
+++ b/pangeo-notebook/environment.yml
@@ -88,5 +88,3 @@ dependencies:
  - xpublish
  - xrft
  - zarr
- - pip:
-    - stackstac

--- a/pangeo-notebook/packages.txt
+++ b/pangeo-notebook/packages.txt
@@ -7,7 +7,7 @@ affine-2.3.0
 aiobotocore-1.3.0
 aiohttp-3.7.4
 aioitertools-0.7.1
-alembic-1.5.8
+alembic-1.6.0
 alsa-lib-1.2.3
 amqp-5.0.6
 anyio-2.2.0
@@ -22,12 +22,12 @@ async_generator-1.10
 atk-1.0-2.36.0
 attrs-20.3.0
 av-8.0.3
-aws-c-cal-0.4.5
-aws-c-common-0.5.8
+aws-c-cal-0.5.6
+aws-c-common-0.5.10
 aws-c-event-stream-0.2.7
-aws-c-io-0.9.4
+aws-c-io-0.9.11
 aws-checksums-0.1.11
-aws-sdk-cpp-1.8.151
+aws-sdk-cpp-1.8.186
 awscli-1.19.49
 azure-core-1.12.0
 azure-datalake-store-0.0.51
@@ -62,7 +62,7 @@ cached_property-1.5.2
 cachetools-4.2.2
 cachey-0.2.1
 cairo-1.16.0
-cartopy-0.19.0
+cartopy-0.19.0.post1
 celery-5.0.5
 certifi-2020.12.5
 certipy-0.1.3
@@ -172,7 +172,7 @@ gts-0.7.6
 h11-0.12.0
 h5netcdf-0.11.0
 h5py-3.2.1
-harfbuzz-2.8.0
+harfbuzz-2.8.1
 hdf4-4.2.13
 hdf5-1.10.6
 heapdict-1.0.1
@@ -443,6 +443,7 @@ rechunker-0.4.2
 redis-py-3.5.3
 requests-2.25.1
 requests-oauthlib-1.3.0
+retrying-1.3.3
 rio-cogeo-2.0.1
 rioxarray-0.3.1
 rsa-4.7.2
@@ -462,13 +463,14 @@ send2trash-1.5.0
 setuptools-49.6.0
 shapely-1.7.1
 simpervisor-0.4
-six-1.15.0
+six-1.16.0
 snappy-1.1.8
 sniffio-1.2.0
 snuggs-1.4.7
 sortedcontainers-2.3.0
 soupsieve-2.0.1
 sparse-0.12.0
+spatialpandas-0.3.6
 sqlalchemy-1.4.13
 sqlite-3.35.5
 sshtunnel-0.3.1
@@ -515,7 +517,7 @@ widgetsnbextension-3.5.1
 wrapt-1.12.1
 x264-1!161.3030
 xarray-0.17.0
-xarray-spatial-0.1.8
+xarray-spatial-0.2.0
 xarray_leaflet-0.1.13
 xarrayutils-0.1.3
 xcape-0.1.2

--- a/pangeo-notebook/requirements.txt
+++ b/pangeo-notebook/requirements.txt
@@ -1,0 +1,1 @@
+stackstac


### PR DESCRIPTION
following up #207 . Since we're using conda-lock files to build the image, we have a separate step for picking up pip installs from a requirements.txt instead of adding these under -pip: in the environment.yml