### PR TITLE
Fix link to dockerhub org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Publish Status](https://github.com/pangeo-data/pangeo-docker-images/workflows/Publish/badge.svg)
 ![DockerHub Version](https://img.shields.io/docker/v/pangeo/base-image?sort=date)
 
-Latest DockerHub Images: https://hub.docker.com/orgs/pangeo/repositories
+Latest DockerHub Images: https://hub.docker.com/u/pangeo
 | Image           | Description                                   |  Size | Pulls |
 |-----------------|-----------------------------------------------|--------------|-------------|
 | base-image      | Foundational Dockerfile for builds            | ![](https://img.shields.io/docker/image-size/pangeo/base-image?sort=date) | ![](https://img.shields.io/docker/pulls/pangeo/base-image?sort=date)


### PR DESCRIPTION
The current link only works if you are logged in