### PR TITLE
rollback ubuntu version bump in base image

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.10
+FROM ubuntu:20.04
 # build file for pangeo images
 
 LABEL org.opencontainers.image.source=https://github.com/pangeo-data/pangeo-docker-images


### PR DESCRIPTION
This rolls back an accidental version bump to ubuntu in our base image. See https://github.com/pangeo-data/pangeo-docker-images/pull/221 for more detail.