### PR TITLE
pin cartopy >= 0.20

### DIFF
--- a/pangeo-notebook/environment.yml
+++ b/pangeo-notebook/environment.yml
@@ -9,7 +9,7 @@ dependencies:
  - awscli
  - boto3
  - bottleneck
- - cartopy
+ - cartopy >= 0.20.0
  - cfgrib
  - cmip6_preprocessing
  - ciso

--- a/tests/test_pangeo-notebook.py
+++ b/tests/test_pangeo-notebook.py
@@ -14,6 +14,10 @@ packages = [
 @pytest.mark.parametrize('package_name', packages, ids=packages)
 def test_import(package_name):
     importlib.import_module(package_name)
+    
+def test_cartopy_downloads():
+    import cartopy
+    _ = cartopy.io.shapereader.natural_earth()  # should trigger download
 
 def test_start():
     print(os.environ)


### PR DESCRIPTION
The NaturalEarth features download site is broken, and Cartopy has updated its vector download location to point to AWS (https://github.com/SciTools/cartopy/pull/1833).

We need to get this release of cartopy into our Pangeo environments asap.