### PR TITLE
Enable binder links to pangeo-notebook image in this repository

### DIFF
--- a/.binder
+++ b/.binder
@@ -1,0 +1,1 @@
+pangeo-notebook

--- a/.github/workflows/Binder.yml
+++ b/.github/workflows/Binder.yml
@@ -1,0 +1,15 @@
+# Trigger build on mybinder.org for faster startup
+# https://github.com/jupyterhub/repo2docker-action#cache-builds-on-mybinderorg
+name: Binder
+on: [push]
+
+jobs:
+  # NOTE: look into doing this for pangeo-binders too!
+  Create-MyBinderOrg-Cache:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: cache binder build on mybinder.org
+      uses: jupyterhub/repo2docker-action@master
+      with:
+        NO_PUSH: true
+        MYBINDERORG_TAG: ${{ github.event.ref }}

--- a/.github/workflows/BinderPR.yml
+++ b/.github/workflows/BinderPR.yml
@@ -1,9 +1,9 @@
-# Any PR opened add a comment with binder links
-name: BinderLinks
+# Add Binder Link to PR for testing pangeo-notebook image
+name: BinderPR
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened]
 
 jobs:
   add-binder-links:


### PR DESCRIPTION
I think this might remove the need for a separate pangeo-default-binder repository, by just soft linking the pangeo-notebook directory (`ln -s pangeo-notebook .binder`)

This way people would be able to use binder links like the following (optionally adding nbgitpuller links to specfic content)
* https://mybinder.org/v2/gh/pangeo-data/pangeo-docker-images/2021.09.22
* https://mybinder.org/v2/gh/pangeo-data/pangeo-docker-images/HEAD 

also adds binder links to PRs from https://github.com/jupyterhub/repo2docker-action, even running these images on mybinder.org can be helpful if not doing dask-gateway things...

related to #18
