### PR TITLE
export conda-env-path in requirements.txt and start build steps

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -17,8 +17,9 @@ ENV CONDA_VERSION=4.10.3-6 \
 
 ENV NB_PYTHON_PREFIX=${CONDA_DIR}/envs/${CONDA_ENV} \
     DASK_ROOT_CONFIG=${CONDA_DIR}/etc \
-    HOME=/home/${NB_USER} \
-    PATH=${CONDA_DIR}/bin:${PATH}
+    HOME=/home/${NB_USER}
+    
+ENV PATH=${NB_PYTHON_PREFIX}/bin:${CONDA_DIR}/bin:${PATH}
 
 # required for prefect agent: https://github.com/PrefectHQ/prefect/issues/3061
 ENV DEBIAN_FRONTEND=noninteractive
@@ -121,7 +122,6 @@ ONBUILD RUN echo "Checking for pip 'requirements.txt'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
         ; if test -f "requirements.txt" ; then \
-        export PATH=${NB_PYTHON_PREFIX}/bin:${PATH} \
         && ${NB_PYTHON_PREFIX}/bin/pip install --no-cache-dir -r requirements.txt \
         ; fi
 
@@ -130,7 +130,6 @@ ONBUILD RUN echo "Checking for 'postBuild'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
         ; if test -f "postBuild" ; then \
-        export PATH=${NB_PYTHON_PREFIX}/bin:${PATH} \
         && chmod +x postBuild \
         && ./postBuild \
         && rm -rf /tmp/* \
@@ -146,7 +145,6 @@ ONBUILD RUN echo "Checking for 'start'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
         ; if test -f "start" ; then \
-        export PATH=${NB_PYTHON_PREFIX}/bin:${PATH} \
         && chmod +x start \
         && cp start /srv/start \
         ; fi

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -122,7 +122,7 @@ ONBUILD RUN echo "Checking for pip 'requirements.txt'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
         ; if test -f "requirements.txt" ; then \
-        && ${NB_PYTHON_PREFIX}/bin/pip install --no-cache-dir -r requirements.txt \
+        ${NB_PYTHON_PREFIX}/bin/pip install --no-cache-dir -r requirements.txt \
         ; fi
 
 # Run postBuild script within "pangeo" environment
@@ -130,7 +130,7 @@ ONBUILD RUN echo "Checking for 'postBuild'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
         ; if test -f "postBuild" ; then \
-        && chmod +x postBuild \
+        chmod +x postBuild \
         && ./postBuild \
         && rm -rf /tmp/* \
         && rm -rf ${HOME}/.cache ${HOME}/.npm ${HOME}/.yarn \
@@ -145,7 +145,7 @@ ONBUILD RUN echo "Checking for 'start'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
         ; if test -f "start" ; then \
-        && chmod +x start \
+        chmod +x start \
         && cp start /srv/start \
         ; fi
 # ----------------------

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -121,6 +121,7 @@ ONBUILD RUN echo "Checking for pip 'requirements.txt'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
         ; if test -f "requirements.txt" ; then \
+        export PATH=${NB_PYTHON_PREFIX}/bin:${PATH} \
         ${NB_PYTHON_PREFIX}/bin/pip install --no-cache-dir -r requirements.txt \
         ; fi
 
@@ -145,6 +146,7 @@ ONBUILD RUN echo "Checking for 'start'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
         ; if test -f "start" ; then \
+        export PATH=${NB_PYTHON_PREFIX}/bin:${PATH} \
         chmod +x start \
         && cp start /srv/start \
         ; fi

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -122,7 +122,7 @@ ONBUILD RUN echo "Checking for pip 'requirements.txt'..." \
         ; [ -d .binder ] && cd .binder \
         ; if test -f "requirements.txt" ; then \
         export PATH=${NB_PYTHON_PREFIX}/bin:${PATH} \
-        ${NB_PYTHON_PREFIX}/bin/pip install --no-cache-dir -r requirements.txt \
+        && ${NB_PYTHON_PREFIX}/bin/pip install --no-cache-dir -r requirements.txt \
         ; fi
 
 # Run postBuild script within "pangeo" environment
@@ -147,7 +147,7 @@ ONBUILD RUN echo "Checking for 'start'..." \
         ; [ -d .binder ] && cd .binder \
         ; if test -f "start" ; then \
         export PATH=${NB_PYTHON_PREFIX}/bin:${PATH} \
-        chmod +x start \
+        && chmod +x start \
         && cp start /srv/start \
         ; fi
 # ----------------------


### PR DESCRIPTION
This is trying to fix an issue where executables in the conda environment are not in the environments PATH during the `requirements.txt` and `start` build steps. I ran into this when installing `git` via conda and installing a python package from source via the `requirements.txt` file. 