### PR TITLE
Replace version pinned Miniforge with latest Mambaforge

### DIFF
--- a/.github/workflows/CondaLock.yml
+++ b/.github/workflows/CondaLock.yml
@@ -34,11 +34,12 @@ jobs:
           key:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('environment-condalock.yml') }}
 
-      - name: Setup Conda Environment with Miniforge
+      - name: Setup Conda Environment with Mambaforge
         uses: conda-incubator/setup-miniconda@v2
         with:
            # Match base-image/Dockerfile version
-           miniforge-version: 4.10.3-7
+           miniforge-version: latest
+           miniforge-variant: Mambaforge
            environment-file: environment-condalock.yml
            activate-environment: condalock
            use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -4,10 +4,14 @@ FROM ubuntu:20.04
 LABEL org.opencontainers.image.source=https://github.com/pangeo-data/pangeo-docker-images
 
 # Run this section as root
-# try to keep conda version in sync with repo2docker?
-# https://github.com/jupyterhub/repo2docker/blob/297c7955d208f3595c4d5bc2b079953199bb1f35/repo2docker/buildpacks/conda/install-miniforge.bash#L8-L9# ========================
-ENV CONDA_VERSION=4.10.3-7 \
-    MAMBA_VERSION=0.17 \
+# FIXME: Pin CONDA_VERSION only to "major.minor". Currently we can't just set
+#        CONDA_VERSION without including ".patch-build" as its used as a part in
+#        a download URL that requires the full version specification. The github
+#        repo's tags are available before the GitHub releases are made as well.
+# CONDA_VERSION: A miniforge release version https://github.com/conda-forge/miniforge/releases
+# MAMBA_VERSION: A conda-forge package version https://anaconda.org/conda-forge/mamba
+ENV CONDA_VERSION=4.11.0-0 \
+    MAMBA_VERSION=0.20 \
     CONDA_ENV=notebook \
     NB_USER=jovyan \
     NB_UID=1000 \

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -4,13 +4,13 @@ FROM ubuntu:20.04
 LABEL org.opencontainers.image.source=https://github.com/pangeo-data/pangeo-docker-images
 
 # Run this section as root
-# FIXME: Pin CONDA_VERSION only to "major.minor". Currently we can't just set
-#        CONDA_VERSION without including ".patch-build" as its used as a part in
-#        a download URL that requires the full version specification. The github
-#        repo's tags are available before the GitHub releases are made as well.
-# CONDA_VERSION: A miniforge release version https://github.com/conda-forge/miniforge/releases
-# MAMBA_VERSION: A conda-forge package version https://anaconda.org/conda-forge/mamba
-ENV CONDA_VERSION=4.11.0-0 \
+# CONDA_VERSION: A miniforge release version found at
+#                https://github.com/conda-forge/miniforge/releases specified to
+#                either just "major" or "major.minor", but always excluding
+#                ".patch-build".
+# MAMBA_VERSION: A conda-forge package version found at
+#                https://anaconda.org/conda-forge/mamba
+ENV CONDA_VERSION=4.11 \
     MAMBA_VERSION=0.20 \
     CONDA_ENV=notebook \
     NB_USER=jovyan \
@@ -42,7 +42,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN echo "Installing Apt-get packages..." \
     && apt-get update --fix-missing \
     && apt-get install -y apt-utils 2> /dev/null \
-    && apt-get install -y wget zip tzdata \
+    && apt-get install -y wget zip tzdata jq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 # ========================
@@ -51,7 +51,11 @@ USER ${NB_USER}
 WORKDIR ${HOME}
 
 RUN echo "Installing Miniforge..." \
-    && URL="https://github.com/conda-forge/miniforge/releases/download/${CONDA_VERSION}/Miniforge3-${CONDA_VERSION}-Linux-x86_64.sh" \
+    && wget --quiet "https://api.github.com/repos/conda-forge/miniforge/releases?per_page=100" -O releases.json \
+    && MINIFORGE_VERSION=$(cat releases.json | jq --raw-output "[.[] | .tag_name | select(. | startswith(\"${CONDA_VERSION}.\"))][0]") \
+    && rm releases.json \
+    && echo "Downloading miniforge version ${MINIFORGE_VERSION}" \
+    && URL="https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh" \
     && wget --quiet ${URL} -O miniconda.sh \
     && /bin/bash miniconda.sh -u -b -p ${CONDA_DIR} \
     && rm miniconda.sh \

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -4,15 +4,7 @@ FROM ubuntu:20.04
 LABEL org.opencontainers.image.source=https://github.com/pangeo-data/pangeo-docker-images
 
 # Run this section as root
-# CONDA_VERSION: A miniforge release version found at
-#                https://github.com/conda-forge/miniforge/releases specified to
-#                either just "major" or "major.minor", but always excluding
-#                ".patch-build".
-# MAMBA_VERSION: A conda-forge package version found at
-#                https://anaconda.org/conda-forge/mamba
-ENV CONDA_VERSION=4.11 \
-    MAMBA_VERSION=0.20 \
-    CONDA_ENV=notebook \
+ENV CONDA_ENV=notebook \
     NB_USER=jovyan \
     NB_UID=1000 \
     SHELL=/bin/bash \
@@ -42,7 +34,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN echo "Installing Apt-get packages..." \
     && apt-get update --fix-missing \
     && apt-get install -y apt-utils 2> /dev/null \
-    && apt-get install -y wget zip tzdata jq \
+    && apt-get install -y wget zip tzdata \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 # ========================
@@ -50,16 +42,11 @@ RUN echo "Installing Apt-get packages..." \
 USER ${NB_USER}
 WORKDIR ${HOME}
 
-RUN echo "Installing Miniforge..." \
-    && wget --quiet "https://api.github.com/repos/conda-forge/miniforge/releases?per_page=100" -O releases.json \
-    && MINIFORGE_VERSION=$(cat releases.json | jq --raw-output "[.[] | .tag_name | select(. | startswith(\"${CONDA_VERSION}.\"))][0]") \
-    && rm releases.json \
-    && echo "Downloading miniforge version ${MINIFORGE_VERSION}" \
-    && URL="https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh" \
-    && wget --quiet ${URL} -O miniconda.sh \
-    && /bin/bash miniconda.sh -u -b -p ${CONDA_DIR} \
-    && rm miniconda.sh \
-    && conda install -y -c conda-forge mamba=${MAMBA_VERSION} \
+RUN echo "Installing Mambaforge..." \
+    && URL="https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh" \
+    && wget --quiet ${URL} -O installer.sh \
+    && /bin/bash installer.sh -u -b -p ${CONDA_DIR} \
+    && rm installer.sh \
     && mamba clean -afy \
     && find ${CONDA_DIR} -follow -type f -name '*.a' -delete \
     && find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete


### PR DESCRIPTION
A maintenance update of the miniforge version and mamba version. To avoid needing to make this kind of update too often, I've also added logic to specify the miniforge version by `major.minor` instead of doing it with `major.minor.patch-build`.

- The miniforge version was pinned to `4.10.3-7` and is via this PR pinned to be `4.11` which currently resolves to `4.11.0-0`.
- The mamba version was pinned to `0.17` and is now pinned to `0.20` which currently resolves to `0.20.0`.

Note that to specify the miniforge version by `major.minor` only, we needed logic to find the latest version matching that as the installation process is to download a specific URL including the exact version. This logic was implemented using a GitHub API and the CLI tool `jq` which was also added to parse out the latest matching version.
 
### Related issue

This PR is a result of me trying to solve https://github.com/pangeo-data/jupyter-earth/issues/101 by updating the mamba version where we rely on the `pangeo/pangeo-notebook` image as a base image.