### PR TITLE
small bash script to get package versions in each tag

### DIFF
--- a/get_version.sh
+++ b/get_version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Get version of LIBARY in every tagged release
+
+LIBRARY=$1
+echo "Getting package history for: $LIBRARY"
+echo "========="
+
+for crt_tag in $(git tag | tail -r)
+do
+  echo $crt_tag
+  git checkout $crt_tag --quiet
+  grep $LIBRARY pangeo-notebook/packages.txt
+  echo "--"
+done
+
+git checkout master


### PR DESCRIPTION
In https://github.com/2i2c-org/infrastructure/issues/1031  @choldgraf asked "What is the easiest way to answer the question "when did package X get updated in the Pangeo image, and which release is associated with it?"

This script is a quick way to answer that question. 

```
Getting package history for: distributed
=========
2022.02.04
distributed-2022.1.1
--
2022.01.31
distributed-2022.1.1
--
2021.12.02
distributed-2021.11.2
--
2021.11.09
distributed-2021.11.1
--
2021.11.07
distributed-2021.11.0
--
2021.11.04
distributed-2021.10.0
--
2021.10.19
distributed-2021.9.1
```

I also played around with a one-liner git command which is helpful for figuring out the *specific date and commit* that a package changed, but the you have to cross-reference our image date tags which are done manually and sporadically: 

`export LIBRARY=distributed 
git log --pretty='commit %h %as' -L "/${LIBRARY}/,+1:pangeo-notebook/packages.txt" | grep "\+${LIBRARY}\|commit" | grep "\+${LIBRARY}" -B1`
