### PR TITLE
Document the base-image & minor cleanup

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -4,34 +4,46 @@ FROM ubuntu:20.04
 
 LABEL org.opencontainers.image.source=https://github.com/pangeo-data/pangeo-docker-images
 
-# Run this section as root
+# Setup environment to match variables set by repo2docker as much as possible
+# The name of the conda environment into which the requested packages are installed
 ENV CONDA_ENV=notebook \
+    # Tell apt-get to not block installs by asking for interactive human input
+    DEBIAN_FRONTEND=noninteractive \
+    # Set username, uid and gid (same as uid) of non-root user the container will be run as
     NB_USER=jovyan \
     NB_UID=1000 \
+    # Use /bin/bash as shell, not the default /bin/sh (arrow keys, etc don't work then)
     SHELL=/bin/bash \
+    # Setup locale to be UTF-8, avoiding gnarly hard to debug encoding errors
     LANG=C.UTF-8  \
     LC_ALL=C.UTF-8 \
-    CONDA_DIR=/srv/conda
+    # Install conda in the same place repo2docker does
+    CONDA_DIR=/srv/conda \
+    # Path to the python environment where the jupyter notebook packages are installed
+    NB_PYTHON_PREFIX=${CONDA_DIR}/envs/${CONDA_ENV} \
+    # Home directory of our non-root user
+    HOME=/home/${NB_USER} \
+    # Add both our notebook env as well as default conda installation to $PATH
+    PATH=${NB_PYTHON_PREFIX}/bin:${CONDA_DIR}/bin:${PATH}
 
-ENV NB_PYTHON_PREFIX=${CONDA_DIR}/envs/${CONDA_ENV} \
-    DASK_ROOT_CONFIG=${CONDA_DIR}/etc \
-    HOME=/home/${NB_USER}
+# Ask dask to read config from ${CONDA_DIR}/etc rather than
+# the default of /etc, since the non-root jovyan user can write
+# to ${CONDA_DIR}/etc but not to /etc
+ENV DASK_ROOT_CONFIG=${CONDA_DIR}/etc
 
-ENV PATH=${NB_PYTHON_PREFIX}/bin:${CONDA_DIR}/bin:${PATH}
-
-# required for prefect agent: https://github.com/PrefectHQ/prefect/issues/3061
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Create jovyan user, permissions, add conda init to startup script
 RUN echo "Creating ${NB_USER} user..." \
+    # Create a group for the user to be part of, with gid same as uid
     && groupadd --gid ${NB_UID} ${NB_USER}  \
+    # Create non-root user, with given gid, uid and create $HOME
     && useradd --create-home --gid ${NB_UID} --no-log-init --uid ${NB_UID} ${NB_USER} \
-    && echo ". ${CONDA_DIR}/etc/profile.d/conda.sh ; conda activate ${CONDA_ENV}" > /etc/profile.d/init_conda.sh \
+    # Make sure that /srv is owned by non-root user, so we can install things there
     && chown -R ${NB_USER}:${NB_USER} /srv
 
-# SEE: https://github.com/phusion/baseimage-docker/issues/58
-ARG DEBIAN_FRONTEND=noninteractive
+# Run conda activate each time a bash shell starts, so users don't have to manually type conda activate
+# Note this is only read by shell, not by python
+RUN echo ". ${CONDA_DIR}/etc/profile.d/conda.sh ; conda activate ${CONDA_ENV}" > /etc/profile.d/init_conda.sh \
 
+# Install basic apt packages
 RUN echo "Installing Apt-get packages..." \
     && apt-get update --fix-missing > /dev/null \
     && apt-get install -y apt-utils wget zip tzdata > /dev/null \
@@ -42,12 +54,15 @@ RUN echo "Installing Apt-get packages..." \
 USER ${NB_USER}
 WORKDIR ${HOME}
 
+# Install latest mambaforge in ${CONDA_DIR}
 RUN echo "Installing Mambaforge..." \
     && URL="https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh" \
     && wget --quiet ${URL} -O installer.sh \
     && /bin/bash installer.sh -u -b -p ${CONDA_DIR} \
     && rm installer.sh \
     && mamba clean -afy \
+    # After installing the packages, we cleanup some unnecessary files
+    # to try reduce image size - see https://jcristharif.com/conda-docker-tips.html
     && find ${CONDA_DIR} -follow -type f -name '*.a' -delete \
     && find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete
 
@@ -89,6 +104,7 @@ ONBUILD RUN echo "Checking for 'apt.txt'..." \
         ; [ -d .binder ] && cd .binder \
         ; if test -f "apt.txt" ; then \
         apt-get update --fix-missing > /dev/null \
+        # Read apt.txt line by line, and execute apt-get install -y for each line in apt.txt
         && xargs -a apt.txt apt-get install -y \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -70,7 +70,6 @@ ONBUILD RUN echo "Checking for 'binder' or '.binder' subfolder" \
         echo "Using './' build context" \
         ; fi
 
-ONBUILD ARG DEBIAN_FRONTEND=noninteractive
 ONBUILD RUN echo "Checking for 'apt.txt'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -24,9 +24,10 @@ ENV CONDA_ENV=notebook \
 # Path to the python environment where the jupyter notebook packages are installed
 ENV NB_PYTHON_PREFIX=${CONDA_DIR}/envs/${CONDA_ENV} \
     # Home directory of our non-root user
-    HOME=/home/${NB_USER} \
-    # Add both our notebook env as well as default conda installation to $PATH
-    PATH=${NB_PYTHON_PREFIX}/bin:${CONDA_DIR}/bin:${PATH}
+    HOME=/home/${NB_USER}
+
+# Add both our notebook env as well as default conda installation to $PATH
+ENV PATH=${NB_PYTHON_PREFIX}/bin:${CONDA_DIR}/bin:${PATH}
 
 # Ask dask to read config from ${CONDA_DIR}/etc rather than
 # the default of /etc, since the non-root jovyan user can write

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -18,9 +18,11 @@ ENV CONDA_ENV=notebook \
     LANG=C.UTF-8  \
     LC_ALL=C.UTF-8 \
     # Install conda in the same place repo2docker does
-    CONDA_DIR=/srv/conda \
-    # Path to the python environment where the jupyter notebook packages are installed
-    NB_PYTHON_PREFIX=${CONDA_DIR}/envs/${CONDA_ENV} \
+    CONDA_DIR=/srv/conda
+
+# All env vars that reference other env vars need to be in their own ENV block
+# Path to the python environment where the jupyter notebook packages are installed
+ENV NB_PYTHON_PREFIX=${CONDA_DIR}/envs/${CONDA_ENV} \
     # Home directory of our non-root user
     HOME=/home/${NB_USER} \
     # Add both our notebook env as well as default conda installation to $PATH

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -49,7 +49,7 @@ RUN echo "Creating ${NB_USER} user..." \
 # Note this is only read by shell, but not by the jupyter notebook - that relies
 # on us starting the correct `python` process, which we do by adding the notebook conda environment's
 # bin to PATH earlier ($NB_PYTHON_PREFIX/bin)
-RUN echo ". ${CONDA_DIR}/etc/profile.d/conda.sh ; conda activate ${CONDA_ENV}" > /etc/profile.d/init_conda.sh \
+RUN echo ". ${CONDA_DIR}/etc/profile.d/conda.sh ; conda activate ${CONDA_ENV}" > /etc/profile.d/init_conda.sh
 
 # Install basic apt packages
 RUN echo "Installing Apt-get packages..." \

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -161,7 +161,7 @@ ONBUILD RUN echo "Checking for pip 'requirements.txt'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
         ; if test -f "requirements.txt" ; then \
-        ${NB_PYTHON_PREFIX}/bin/pip install --no-cache-dir -r requirements.txt \
+        ${NB_PYTHON_PREFIX}/bin/pip install --no-cache -r requirements.txt \
         ; fi
 
 # If a postBuild file exists, run it!

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -27,6 +27,9 @@ ENV NB_PYTHON_PREFIX=${CONDA_DIR}/envs/${CONDA_ENV} \
     HOME=/home/${NB_USER}
 
 # Add both our notebook env as well as default conda installation to $PATH
+# Thus, when we start a `python` process (for kernels, or notebooks, etc),
+# it loads the python in the notebook conda environment, as that comes
+# first here.
 ENV PATH=${NB_PYTHON_PREFIX}/bin:${CONDA_DIR}/bin:${PATH}
 
 # Ask dask to read config from ${CONDA_DIR}/etc rather than
@@ -43,7 +46,9 @@ RUN echo "Creating ${NB_USER} user..." \
     && chown -R ${NB_USER}:${NB_USER} /srv
 
 # Run conda activate each time a bash shell starts, so users don't have to manually type conda activate
-# Note this is only read by shell, not by python
+# Note this is only read by shell, but not by the jupyter notebook - that relies
+# on us starting the correct `python` process, which we do by adding the notebook conda environment's
+# bin to PATH earlier ($NB_PYTHON_PREFIX/bin)
 RUN echo ". ${CONDA_DIR}/etc/profile.d/conda.sh ; conda activate ${CONDA_ENV}" > /etc/profile.d/init_conda.sh \
 
 # Install basic apt packages

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -75,7 +75,12 @@ ENTRYPOINT ["/srv/start"]
 
 # We use ONBUILD (https://docs.docker.com/engine/reference/builder/#onbuild)
 # to support triggering certain behavior when specific files exist in the directories of our
-# child images (such as base-notebook, pangeo-notebook, etc). This is
+# child images (such as base-notebook, pangeo-notebook, etc). For example,
+# in pangeo-notebook/Dockerfile, we *only* inherit from base-image:master, and
+# that triggers all these ONBUILD directives - it is as if these ONBUILD
+# directives are located inside pangeo-notebook/Dockerfile. This lets us
+# keep the Dockerfiles for our child docker images simple, and customize
+# them by just adding files with known names to them. This is
 # to *mimic* the repo2docker behavior, where users can just add
 # environment.yml, requirements.txt, apt.txt etc files to get certain
 # behavior without having to understand how Dockerfiles work. We use

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,3 +1,4 @@
+# Dockerfile for base image of all pangeo images
 FROM ubuntu:20.04
 # build file for pangeo images
 
@@ -15,7 +16,7 @@ ENV CONDA_ENV=notebook \
 ENV NB_PYTHON_PREFIX=${CONDA_DIR}/envs/${CONDA_ENV} \
     DASK_ROOT_CONFIG=${CONDA_DIR}/etc \
     HOME=/home/${NB_USER}
-    
+
 ENV PATH=${NB_PYTHON_PREFIX}/bin:${CONDA_DIR}/bin:${PATH}
 
 # required for prefect agent: https://github.com/PrefectHQ/prefect/issues/3061
@@ -54,13 +55,24 @@ EXPOSE 8888
 ENTRYPOINT ["/srv/start"]
 #CMD ["jupyter", "notebook", "--ip", "0.0.0.0"]
 
-# Only run these if used as a base image
+# We use ONBUILD (https://docs.docker.com/engine/reference/builder/#onbuild)
+# to support triggering certain behavior when specific files exist in the directories of our
+# child images (such as base-notebook, pangeo-notebook, etc). This is
+# to *mimic* the repo2docker behavior, where users can just add
+# environment.yml, requirements.txt, apt.txt etc files to get certain
+# behavior without having to understand how Dockerfiles work. We use
+# ONBUILD to support a subset of the files that repo2docker supports.
+# We do not use repo2docker itself here, to make the images much smaller
+# and easier to reason about.
 # ----------------------
 ONBUILD USER root
 # FIXME (?): user and home folder is hardcoded for now
 # FIXME (?): this line breaks the cache of all steps below
 ONBUILD COPY --chown=jovyan:jovyan . /home/jovyan
 
+# repo2docker will load files from a .binder or binder directory if
+# present. We check if those directories exist, and print a diagnostic
+# message here.
 ONBUILD RUN echo "Checking for 'binder' or '.binder' subfolder" \
         ; if [ -d binder ] ; then \
         echo "Using 'binder/' build context" \
@@ -70,6 +82,8 @@ ONBUILD RUN echo "Checking for 'binder' or '.binder' subfolder" \
         echo "Using './' build context" \
         ; fi
 
+# Install apt packages specified in a apt.txt file if it exists.
+# Unlike repo2docker, blank lines nor comments are supported here.
 ONBUILD RUN echo "Checking for 'apt.txt'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
@@ -80,7 +94,9 @@ ONBUILD RUN echo "Checking for 'apt.txt'..." \
         && rm -rf /var/lib/apt/lists/* \
         ; fi
 
-# Copy jupyter_notebook_config.py to /etc/jupyter
+# If a jupyter_notebook_config.py exists, copy it to /etc/jupyter so
+# it will be read by jupyter processes when they start. This feature is
+# not available in repo2docker.
 ONBUILD RUN echo "Checking for 'jupyter_notebook_config.py'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
@@ -91,7 +107,19 @@ ONBUILD RUN echo "Checking for 'jupyter_notebook_config.py'..." \
 
 ONBUILD USER ${NB_USER}
 
-# Create "notebook" conda environment and dask labextensions
+# We want to keep our images as reproducible as possible. If a lock
+# file with exact versions of all required packages is present, we use
+# it to install packages. conda-lock (https://github.com/conda-incubator/conda-lock)
+# is used to generate this conda-linux-64.lock file from a given environment.yml
+# file - so we get the exact same versions each time the image is built. This
+# also lets us see what packages have changed between two images by diffing
+# the contents of the lock file between those image versions.
+# If a lock file is not present, we use the environment.yml file. And
+# if that is also not present, we use the pangeo-notebook conda-forge
+# package (https://anaconda.org/conda-forge/pangeo-notebook) to install
+# a list of base packages.
+# After installing the packages, we cleanup some unnecessary files
+# to try reduce image size - see https://jcristharif.com/conda-docker-tips.html
 ONBUILD RUN echo "Checking for 'conda-linux-64.lock' or 'environment.yml'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
@@ -110,8 +138,9 @@ ONBUILD RUN echo "Checking for 'conda-linux-64.lock' or 'environment.yml'..." \
         find ${NB_PYTHON_PREFIX}/lib/python*/site-packages/bokeh/server/static -follow -type f -name '*.js' ! -name '*.min.js' -delete \
         ; fi
 
-# Install pip packages
-# remove cache https://github.com/pypa/pip/pull/6391 ?
+# If a requirements.txt file exists, use pip to install packages
+# listed there. We don't want to save cached wheels in the image
+# to avoid wasting space.
 ONBUILD RUN echo "Checking for pip 'requirements.txt'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
@@ -119,7 +148,10 @@ ONBUILD RUN echo "Checking for pip 'requirements.txt'..." \
         ${NB_PYTHON_PREFIX}/bin/pip install --no-cache-dir -r requirements.txt \
         ; fi
 
-# Run postBuild script within "pangeo" environment
+# If a postBuild file exists, run it!
+# After it's done, we try to remove any possible cruft commands there
+# leave behind under $HOME - particularly stuff that jupyterlab extensions
+# leave behind.
 ONBUILD RUN echo "Checking for 'postBuild'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
@@ -134,7 +166,8 @@ ONBUILD RUN echo "Checking for 'postBuild'..." \
         && find ${CONDA_DIR} -follow -type f -name '*.js.map' -delete \
         ; fi
 
-# Overwrite start entrypoint script if present
+# If a start file exists, put that under /srv/start. Used in the
+# same way as a start file in repo2docker.
 ONBUILD RUN echo "Checking for 'start'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -32,9 +32,8 @@ RUN echo "Creating ${NB_USER} user..." \
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN echo "Installing Apt-get packages..." \
-    && apt-get update --fix-missing \
-    && apt-get install -y apt-utils 2> /dev/null \
-    && apt-get install -y wget zip tzdata \
+    && apt-get update --fix-missing > /dev/null \
+    && apt-get install -y apt-utils wget zip tzdata > /dev/null \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 # ========================
@@ -76,7 +75,7 @@ ONBUILD RUN echo "Checking for 'apt.txt'..." \
         ; [ -d binder ] && cd binder \
         ; [ -d .binder ] && cd .binder \
         ; if test -f "apt.txt" ; then \
-        apt-get update --fix-missing \
+        apt-get update --fix-missing > /dev/null \
         && xargs -a apt.txt apt-get install -y \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -1,1 +1,5 @@
+# ONBUILD instructions in base-image/Dockerfile are used to
+# perform certain actions based on the presence of specific
+# files (such as conda-linux-64.lock, start) in this repo.
+# Refer to the base-image/Dockerfile for documentation.
 FROM pangeo/base-image:master

--- a/ml-notebook/Dockerfile
+++ b/ml-notebook/Dockerfile
@@ -1,1 +1,5 @@
+# ONBUILD instructions in base-image/Dockerfile are used to
+# perform certain actions based on the presence of specific
+# files (such as conda-linux-64.lock, start) in this repo.
+# Refer to the base-image/Dockerfile for documentation.
 FROM pangeo/base-image:master

--- a/pangeo-notebook/Dockerfile
+++ b/pangeo-notebook/Dockerfile
@@ -1,1 +1,5 @@
+# ONBUILD instructions in base-image/Dockerfile are used to
+# perform certain actions based on the presence of specific
+# files (such as conda-linux-64.lock, start) in this repo.
+# Refer to the base-image/Dockerfile for documentation.
 FROM pangeo/base-image:master


### PR DESCRIPTION
- Add a lot of inline documentation to the base-image, which is where
  almost all the magic is.
- Install base-image packages in one go, rather than in two
  lines - this is slightly faster.
- Hide stdout from apt-get install from base-image and from
  apt-get update, but not for packages from apt.txt. Earlier
  stderr was being hidden - but that is useful when the package
  installation actually fails
- Use `--no-cache` instead of `--no-cache-dir` when installing
   with pip, to be clearer on what we want.