### PR TITLE
Bump pystac to 1.4.0

### DIFF
--- a/ml-notebook/packages.txt
+++ b/ml-notebook/packages.txt
@@ -471,7 +471,7 @@ pyrsistent==0.18.1
 pyshp==2.2.0
 pysocks==1.7.1
 pyspectral==0.11.0
-pystac==1.2.0
+pystac==1.4.0
 pystac-client==0.3.2
 pytest==7.1.1
 python==3.9.12

--- a/pangeo-notebook/packages.txt
+++ b/pangeo-notebook/packages.txt
@@ -460,7 +460,7 @@ pyrsistent==0.18.1
 pyshp==2.2.0
 pysocks==1.7.1
 pyspectral==0.11.0
-pystac==1.2.0
+pystac==1.4.0
 pystac-client==0.3.2
 pytest==7.1.1
 python==3.9.12


### PR DESCRIPTION
This pull requests bumps pystac to 1.4.0.
Switching to this version would allow using GeoServer based STAC catalogs (or any other STAC implementation that provides multiple media types for STAC catalogs).