### PR TITLE
Add gh-scoped-creds to base-notebook

### DIFF
--- a/base-notebook/conda-linux-64.lock
+++ b/base-notebook/conda-linux-64.lock
@@ -102,7 +102,7 @@ https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.1-pyhd8ed1ab_0.tar.b
 https://conda.anaconda.org/conda-forge/noarch/tblib-1.7.0-pyhd8ed1ab_0.tar.bz2#3d4afc31302aa7be471feb6be048ed76
 https://conda.anaconda.org/conda-forge/noarch/toolz-0.11.2-pyhd8ed1ab_0.tar.bz2#f348d1590550371edfac5ed3c1d44f7e
 https://conda.anaconda.org/conda-forge/noarch/traitlets-5.1.1-pyhd8ed1ab_0.tar.bz2#a1bc9765ef9499760e88f568b3a6622c
-https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.2.0-pyha770c72_0.tar.bz2#0b04e3ee5a310a3bec598a04479e7fa3
+https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.2.0-pyha770c72_1.tar.bz2#f0f7e024f94e23d3bfee0ab777bf335a
 https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2#3563be4c5611a44210d9ba0c16113136
 https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.3.2-pyhd8ed1ab_0.tar.bz2#da6f472c62b4eda0caf05e223729efcd
 https://conda.anaconda.org/conda-forge/noarch/wheel-0.37.1-pyhd8ed1ab_0.tar.bz2#1ca02aaf78d9c70d9a81a3bed5752022
@@ -148,7 +148,7 @@ https://conda.anaconda.org/conda-forge/linux-64/setuptools-62.1.0-py39hf3d152e_0
 https://conda.anaconda.org/conda-forge/linux-64/sniffio-1.2.0-py39hf3d152e_3.tar.bz2#e2cb114a39b27ef1687a0c2c3e793cf6
 https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.1.1-pyhd8ed1ab_0.tar.bz2#5d280406501e79dc7aa9c9ac31d25a80
 https://conda.anaconda.org/conda-forge/linux-64/tornado-6.1-py39hb9d737c_3.tar.bz2#5e13a2d214ed4184969df363a1aab420
-https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.2.0-hd8ed1ab_0.tar.bz2#2f8145b0ba478dc1ac974ac1900d3b66
+https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.2.0-hd8ed1ab_1.tar.bz2#6d9d7480c5780514779967be2ee8b963
 https://conda.anaconda.org/conda-forge/noarch/zict-2.1.0-pyhd8ed1ab_0.tar.bz2#ff4e65768f39040f71cce422799d0f41
 https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.2.0-pyhd8ed1ab_0.tar.bz2#68c9a0ab410c72abd24cbaac57703519
 https://conda.anaconda.org/conda-forge/linux-64/anyio-3.5.0-py39hf3d152e_0.tar.bz2#b0d75a9d3fd02ec079504aabb7cd7ec3
@@ -159,6 +159,7 @@ https://conda.anaconda.org/conda-forge/noarch/bleach-5.0.0-pyhd8ed1ab_0.tar.bz2#
 https://conda.anaconda.org/conda-forge/linux-64/brotlipy-0.7.0-py39hb9d737c_1004.tar.bz2#05a99367d885ec9990f25e74128a8a08
 https://conda.anaconda.org/conda-forge/linux-64/cryptography-36.0.2-py39hd97740a_1.tar.bz2#dbd00b111b182f40ecf998c8289fc4a2
 https://conda.anaconda.org/conda-forge/noarch/dask-core-2022.4.1-pyhd8ed1ab_0.tar.bz2#5fee12b7b8acb170c47d425d3b069f3c
+https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.11.3-hd8ed1ab_1.tar.bz2#bd6b6ae37c03e68061574d5e32fe5bd1
 https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.1-pyhd8ed1ab_0.tar.bz2#40b3f446c61729cdd21ed9d85627df6e
 https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.4.0-pyhd8ed1ab_0.tar.bz2#17ec41acce882e5db4efdcc4c01ca7e0
 https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.2.2-pyhd8ed1ab_1.tar.bz2#9967e2ad57f060c15da2a7ba1bfb6997
@@ -199,12 +200,12 @@ https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-6.5.0-pyhd8ed1ab_
 https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.3.1-pyhd8ed1ab_0.tar.bz2#61b279f051eef9c89d58f4d813e75e04
 https://conda.anaconda.org/conda-forge/linux-64/dask-gateway-0.9.0-py39hf3d152e_2.tar.bz2#57f015b6de515b0d5fb7827a62de8fdd
 https://conda.anaconda.org/conda-forge/noarch/jupyter-server-proxy-3.2.1-pyhd8ed1ab_0.tar.bz2#8fdfe5edf206bbfef250c830b5a72aff
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.12.0-pyhd8ed1ab_0.tar.bz2#62b14b14bbe75df451b0ee99d87df16f
+https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.13.0-pyhd8ed1ab_1.tar.bz2#ecead930bfd8c0f629c5b8bf5c1e3508
 https://conda.anaconda.org/conda-forge/noarch/nbconvert-6.5.0-pyhd8ed1ab_0.tar.bz2#156c180588e38b9f41758058824ec50f
 https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.1.0-pyhd8ed1ab_0.tar.bz2#3a8e2c7dcc674f2cb0784f1faba57055
 https://conda.anaconda.org/conda-forge/noarch/python-kubernetes-23.3.0-pyhd8ed1ab_0.tar.bz2#8e49c4eb009af0c15eba1e89dc082f8a
 https://conda.anaconda.org/conda-forge/noarch/dask-kubernetes-2022.1.0-pyhd8ed1ab_0.tar.bz2#3d5b8c0dc8eccd8b2344baff8eafaf47
-https://conda.anaconda.org/conda-forge/noarch/notebook-6.4.10-pyha770c72_0.tar.bz2#7221a3cbd39e1a3101559e4508e54eae
+https://conda.anaconda.org/conda-forge/noarch/notebook-6.4.11-pyha770c72_0.tar.bz2#da25720a88aa3cbb3e16df740783da74
 https://conda.anaconda.org/conda-forge/noarch/nbclassic-0.3.7-pyhd8ed1ab_0.tar.bz2#a8a7139140a7512c90514444444a4991
 https://conda.anaconda.org/conda-forge/noarch/nbgitpuller-1.1.0-pyhd8ed1ab_0.tar.bz2#7939a867db173d59e8f72d860678eb37
 https://conda.anaconda.org/conda-forge/noarch/pangeo-dask-2022.04.18-hd8ed1ab_0.tar.bz2#13ec5446ed3b3d11b47a90f412d6cba1

--- a/base-notebook/packages.txt
+++ b/base-notebook/packages.txt
@@ -54,6 +54,7 @@ greenlet==1.1.2
 heapdict==1.0.1
 idna==3.3
 importlib-metadata==4.11.3
+importlib_metadata==4.11.3
 importlib_resources==5.7.1
 ipykernel==6.13.0
 ipython==8.2.0
@@ -74,7 +75,7 @@ jupyterhub-base==2.2.2
 jupyterhub-singleuser==2.2.2
 jupyterlab==3.3.4
 jupyterlab_pygments==0.2.2
-jupyterlab_server==2.12.0
+jupyterlab_server==2.13.0
 jupyterlab_widgets==1.1.0
 keyutils==1.6.1
 krb5==1.19.3
@@ -125,7 +126,7 @@ nbformat==5.3.0
 nbgitpuller==1.1.0
 ncurses==6.3
 nest-asyncio==1.5.5
-notebook==6.4.10
+notebook==6.4.11
 notebook-shim==0.1.0
 numpy==1.22.3
 oauthlib==3.2.0

--- a/ml-notebook/conda-linux-64.lock
+++ b/ml-notebook/conda-linux-64.lock
@@ -3,7 +3,7 @@
 # input_hash: dbba40963599c71c2ea8bf0cbf1ef7440b0005f1cea557afb5d1608d71527d64
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/linux-64/gh-2.8.0-ha8f183a_0.tar.bz2#7817ecbfff4bf3bcfb357534c5a00b5e
-https://conda.anaconda.org/conda-forge/linux-64/git-lfs-3.1.2-ha770c72_0.tar.bz2#c606e9e8c43c75ff80f0bb13034e6b80
+https://conda.anaconda.org/conda-forge/linux-64/git-lfs-3.1.4-ha770c72_0.tar.bz2#1bd1d0f0bae6a3ed371d7c90b0d79510
 https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2#9a66894dfd07c4510beb6b3f9672ccc0
 https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
 https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2021.10.8-ha878542_0.tar.bz2#575611b8a84f45960e87722eeb51fa26
@@ -269,7 +269,7 @@ https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2#f
 https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2#5844808ffab9ebdb694585b50ba02a96
 https://conda.anaconda.org/conda-forge/noarch/toolz-0.11.2-pyhd8ed1ab_0.tar.bz2#f348d1590550371edfac5ed3c1d44f7e
 https://conda.anaconda.org/conda-forge/noarch/traitlets-5.1.1-pyhd8ed1ab_0.tar.bz2#a1bc9765ef9499760e88f568b3a6622c
-https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.2.0-pyha770c72_0.tar.bz2#0b04e3ee5a310a3bec598a04479e7fa3
+https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.2.0-pyha770c72_1.tar.bz2#f0f7e024f94e23d3bfee0ab777bf335a
 https://conda.anaconda.org/conda-forge/noarch/unidecode-1.3.4-pyhd8ed1ab_0.tar.bz2#6ee0ed0149b472fdf458e4fd18ea1596
 https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2#3563be4c5611a44210d9ba0c16113136
 https://conda.anaconda.org/conda-forge/noarch/webob-1.8.7-pyhd8ed1ab_0.tar.bz2#a8192f3585f341ea66c60c189580ac67
@@ -361,13 +361,13 @@ https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.6-py39hb9d7
 https://conda.anaconda.org/conda-forge/linux-64/setuptools-60.10.0-py39hf3d152e_0.tar.bz2#1d5e7bd9ec2e75cd3b606c58d9e120e8
 https://conda.anaconda.org/conda-forge/linux-64/sniffio-1.2.0-py39hf3d152e_3.tar.bz2#e2cb114a39b27ef1687a0c2c3e793cf6
 https://conda.anaconda.org/conda-forge/linux-64/tensorboard-data-server-0.6.0-py39hd97740a_2.tar.bz2#7a618cdeae52fa632fdd8914dc453ceb
-https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.7.2-h1e4a385_0.tar.bz2#7ed84e0315e9d1b1620a881f1f7e22fc
+https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.8.0-h1e4a385_1.tar.bz2#3a50a4b46dbedbe495d8b3fa6ec2c27a
 https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.1.1-pyhd8ed1ab_0.tar.bz2#5d280406501e79dc7aa9c9ac31d25a80
 https://conda.anaconda.org/conda-forge/linux-64/tornado-6.1-py39hb9d737c_3.tar.bz2#5e13a2d214ed4184969df363a1aab420
 https://conda.anaconda.org/conda-forge/noarch/tqdm-4.64.0-pyhd8ed1ab_0.tar.bz2#6642233f341e1900d0c8e6eddb979c14
 https://conda.anaconda.org/conda-forge/noarch/traittypes-0.2.1-pyh9f0ad1d_2.tar.bz2#7d32ccb5334a6822c28af3e864550618
 https://conda.anaconda.org/conda-forge/noarch/trollsift-0.4.0-pyhd8ed1ab_0.tar.bz2#28417137108bfc7db0a5a87137ab7551
-https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.2.0-hd8ed1ab_0.tar.bz2#2f8145b0ba478dc1ac974ac1900d3b66
+https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.2.0-hd8ed1ab_1.tar.bz2#6d9d7480c5780514779967be2ee8b963
 https://conda.anaconda.org/conda-forge/linux-64/ujson-5.2.0-py39h5a03fae_1.tar.bz2#9827078f4b6c3af7c08517cda58bd1be
 https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-14.0.0-py39hb9d737c_1.tar.bz2#ef84376736d1e8a814ccb06d1d814e6f
 https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.14.0-py39hb9d737c_1.tar.bz2#f8a851de6463445ebf53161a4f41db93
@@ -442,7 +442,7 @@ https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2#cb83a3d6
 https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-1.4.35-py39hb9d737c_0.tar.bz2#aba3f9a2c924f9b91dbc45ed727b1985
 https://conda.anaconda.org/conda-forge/noarch/stack_data-0.2.0-pyhd8ed1ab_0.tar.bz2#8c0ce3e6bf18a0c810125aef58a2a6f3
 https://conda.anaconda.org/conda-forge/linux-64/terminado-0.13.3-py39hf3d152e_1.tar.bz2#bebf6da1adb04ed902ff335e61438a6e
-https://conda.anaconda.org/conda-forge/linux-64/tiledb-py-0.13.3-py39hcd6ad5b_0.tar.bz2#e16c64a2b6d8c79f1172314306b1a9c4
+https://conda.anaconda.org/conda-forge/linux-64/tiledb-py-0.14.0-py39h7d821a0_1.tar.bz2#613d20f7c121cbe8dc5ee18ad634c8ad
 https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.17.6-py39hf3d152e_1.tar.bz2#629569ca82cb91771b65fba986da69dd
 https://conda.anaconda.org/conda-forge/linux-64/yarl-1.7.2-py39hb9d737c_2.tar.bz2#f2f2df8a6238bf5e68c3aaf0e86e08d0
 https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.8.1-py39hb9d737c_1.tar.bz2#8d847048d7b3b3ace26e40731297e37f
@@ -462,7 +462,7 @@ https://conda.anaconda.org/conda-forge/linux-64/jaxlib-0.1.75-py39hde0f152_0.tar
 https://conda.anaconda.org/conda-forge/noarch/jupyter_telemetry-0.1.0-pyhd8ed1ab_1.tar.bz2#bb9ebdb6d5aa2622484aff1faceee181
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2#243f63592c8e449f40cd42eb5cf32f40
 https://conda.anaconda.org/conda-forge/noarch/keras-preprocessing-1.1.2-pyhd8ed1ab_0.tar.bz2#a79b00989a0d89791021902f37fe2f9e
-https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.4.2-h8ff35cd_5.tar.bz2#b566ab30051e692541d0a8b7a2d70d58
+https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.4.2-hb785293_6.tar.bz2#32e7620fb49a6c4974e57825df9dba74
 https://conda.anaconda.org/conda-forge/noarch/marshmallow-oneofschema-3.0.1-pyhd8ed1ab_0.tar.bz2#4feef1f2c0f93b72161bb6c838813b30
 https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.5.1-py39h2fa2bec_0.tar.bz2#739c2c88c887da02e6f4b438bf258936
 https://conda.anaconda.org/conda-forge/linux-64/nb_conda_kernels-2.3.1-py39hf3d152e_1.tar.bz2#ef221076b7cacb498179b1eb3c527c6b
@@ -495,7 +495,7 @@ https://conda.anaconda.org/conda-forge/noarch/descartes-1.1.0-py_4.tar.bz2#32fa3
 https://conda.anaconda.org/conda-forge/linux-64/esmpy-8.2.0-mpi_mpich_py39h8bb458d_101.tar.bz2#347f324dd99dfb0b1479a466213b55bf
 https://conda.anaconda.org/conda-forge/noarch/fastapi-0.75.2-pyhd8ed1ab_0.tar.bz2#4f5576122e79718c6d614ed52cac0588
 https://conda.anaconda.org/conda-forge/noarch/ftfy-6.1.1-pyhd8ed1ab_0.tar.bz2#8112acb97be37967accbbe75436b62d7
-https://conda.anaconda.org/conda-forge/linux-64/gdal-3.4.2-py39hc691d54_5.tar.bz2#ce9771815bd0fde323a9b308e7f3e152
+https://conda.anaconda.org/conda-forge/linux-64/gdal-3.4.2-py39hc691d54_6.tar.bz2#98c29845bb963e073efbcc5140a55ca9
 https://conda.anaconda.org/conda-forge/linux-64/gtk2-2.24.33-h90689f9_2.tar.bz2#957a0255ab58aaf394a91725d73ab422
 https://conda.anaconda.org/conda-forge/noarch/jax-0.3.0-pyhd8ed1ab_0.tar.bz2#b26638fcabe1b5e4aff88f31407ac13a
 https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.52.5-h0a9e6e8_3.tar.bz2#a08562889b985d021550e22443cf0fce
@@ -568,13 +568,13 @@ https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-0.4.6-pyhd8ed
 https://conda.anaconda.org/conda-forge/noarch/intake-0.6.5-pyhd8ed1ab_0.tar.bz2#9b4be120fd2545abd086bfefda0fa0f6
 https://conda.anaconda.org/conda-forge/noarch/jupyter-resource-usage-0.6.1-pyhd8ed1ab_0.tar.bz2#a35cb988cd5b9b9b2d1c6179a8a86974
 https://conda.anaconda.org/conda-forge/noarch/jupyter-server-proxy-3.2.1-pyhd8ed1ab_0.tar.bz2#8fdfe5edf206bbfef250c830b5a72aff
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.12.0-pyhd8ed1ab_0.tar.bz2#62b14b14bbe75df451b0ee99d87df16f
+https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.13.0-pyhd8ed1ab_1.tar.bz2#ecead930bfd8c0f629c5b8bf5c1e3508
 https://conda.anaconda.org/conda-forge/noarch/metpy-1.3.0-pyhd8ed1ab_0.tar.bz2#abf4df8cafc944ae288416f395071bc0
 https://conda.anaconda.org/conda-forge/noarch/msal_extensions-0.3.1-pyhd8ed1ab_0.tar.bz2#6dd32d145f72c2f70ab13981da2eda82
 https://conda.anaconda.org/conda-forge/noarch/msrest-0.6.21-pyh44b312d_0.tar.bz2#1d2ea1f71147bd5ed5222a9f0d6df946
 https://conda.anaconda.org/conda-forge/noarch/nbconvert-6.5.0-pyhd8ed1ab_0.tar.bz2#156c180588e38b9f41758058824ec50f
 https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.1.0-pyhd8ed1ab_0.tar.bz2#3a8e2c7dcc674f2cb0784f1faba57055
-https://conda.anaconda.org/conda-forge/noarch/panel-0.12.7-pyhd8ed1ab_0.tar.bz2#1e0f7d14d996f17b14e9e482e4a01b4d
+https://conda.anaconda.org/conda-forge/noarch/panel-0.13.0-pyhd8ed1ab_0.tar.bz2#54cb4a5e8155c1ba91e7a09b7185b281
 https://conda.anaconda.org/conda-forge/linux-64/parcels-2.3.0-py39hf3d152e_2.tar.bz2#b88763a78ff9d0c3f314526b5890fb1a
 https://conda.anaconda.org/conda-forge/noarch/prefect-1.2.0-pyhd8ed1ab_0.tar.bz2#0ab92cfc39d6c67a548b30e0c1b2fcfb
 https://conda.anaconda.org/conda-forge/noarch/pyspectral-0.11.0-pyhd8ed1ab_0.tar.bz2#7ae8eb4d631745db9a654532e10608eb
@@ -603,7 +603,7 @@ https://conda.anaconda.org/conda-forge/noarch/intake-esm-2021.8.17-pyhd8ed1ab_0.
 https://conda.anaconda.org/conda-forge/noarch/intake-geopandas-0.4.0-pyhd8ed1ab_0.tar.bz2#5d6429a927d1ef3c0d26d81f5d7b31f0
 https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.6.0-pyhd8ed1ab_0.tar.bz2#3d2127b3aaa9193215c87ab9d92f6af0
 https://conda.anaconda.org/conda-forge/noarch/jupyter-panel-proxy-0.1.0-py_0.tar.bz2#80c21feab6100e287707c371c752adea
-https://conda.anaconda.org/conda-forge/noarch/notebook-6.4.10-pyha770c72_0.tar.bz2#7221a3cbd39e1a3101559e4508e54eae
+https://conda.anaconda.org/conda-forge/noarch/notebook-6.4.11-pyha770c72_0.tar.bz2#da25720a88aa3cbb3e16df740783da74
 https://conda.anaconda.org/conda-forge/noarch/satpy-0.36.0-pyhd8ed1ab_0.tar.bz2#33219d79dce152dc6db8501c7c8bc83c
 https://conda.anaconda.org/conda-forge/noarch/tensorboard-2.6.0-pyhd8ed1ab_1.tar.bz2#5ea59c2bbd714e8930c23b50857ef864
 https://conda.anaconda.org/conda-forge/noarch/xskillscore-0.0.24-pyhd8ed1ab_0.tar.bz2#facc58b60c63642243013e12236e3ea7

--- a/ml-notebook/conda-linux-64.lock
+++ b/ml-notebook/conda-linux-64.lock
@@ -377,7 +377,7 @@ https://conda.anaconda.org/conda-forge/linux-64/anyio-3.5.0-py39hf3d152e_0.tar.b
 https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py39hb9d737c_2.tar.bz2#76139de3552a2046135eb0b2d02a9c85
 https://conda.anaconda.org/conda-forge/linux-64/arrow-cpp-6.0.1-py39h01fd06f_8_cpu.tar.bz2#ecdba2c9de06e7ab606c5b4c48218595
 https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.2-pyhd8ed1ab_0.tar.bz2#25e79f9a1133556671becbd65a170c78
-https://conda.anaconda.org/conda-forge/linux-64/av-9.1.1-py39hbd8a108_1.tar.bz2#5134ee232bf08dd32cac35528edc30e6
+https://conda.anaconda.org/conda-forge/linux-64/av-9.2.0-py39hbd8a108_0.tar.bz2#bfe4d864d2424c768345f1f478176eba
 https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2#c5b3edc62d6309088f4970b3eaaa65a6
 https://conda.anaconda.org/conda-forge/noarch/bleach-5.0.0-pyhd8ed1ab_0.tar.bz2#2a2ae7c56b8f72caba261363407b484a
 https://conda.anaconda.org/conda-forge/linux-64/bottleneck-1.3.4-py39hd257fcd_1.tar.bz2#d73b5da2a850eb047a358e97780e29d7

--- a/ml-notebook/packages.txt
+++ b/ml-notebook/packages.txt
@@ -29,7 +29,7 @@ async-timeout==4.0.2
 async_generator==1.10
 atk-1.0==2.36.0
 attrs==21.4.0
-av==9.1.1
+av==9.2.0
 aws-c-cal==0.5.11
 aws-c-common==0.6.2
 aws-c-event-stream==0.2.7

--- a/ml-notebook/packages.txt
+++ b/ml-notebook/packages.txt
@@ -172,7 +172,7 @@ gettext==0.19.8.1
 gflags==2.2.2
 gh==2.8.0
 giflib==5.2.1
-git-lfs==3.1.2
+git-lfs==3.1.4
 glog==0.5.0
 gmp==6.2.1
 gnutls==3.6.13
@@ -249,7 +249,7 @@ jupyterhub-base==2.2.2
 jupyterhub-singleuser==2.2.2
 jupyterlab==3.3.4
 jupyterlab_pygments==0.2.2
-jupyterlab_server==2.12.0
+jupyterlab_server==2.13.0
 jupyterlab_widgets==1.1.0
 jxrlib==1.1
 kealib==1.4.14
@@ -384,7 +384,7 @@ nettle==3.6
 networkx==2.8
 noise==1.2.2
 nomkl==1.0
-notebook==6.4.10
+notebook==6.4.11
 notebook-shim==0.1.0
 nspr==4.32
 nss==3.77
@@ -403,7 +403,7 @@ pamela==1.0.0
 pandas==1.4.2
 pandoc==2.18
 pandocfilters==1.5.0
-panel==0.12.7
+panel==0.13.0
 pangeo-dask==2022.04.18
 pangeo-notebook==2022.04.18
 pango==1.50.7
@@ -556,8 +556,8 @@ terminado==0.13.3
 text-unidecode==1.3
 threadpoolctl==3.1.0
 tifffile==2022.4.8
-tiledb==2.7.2
-tiledb-py==0.13.3
+tiledb==2.8.0
+tiledb-py==0.14.0
 timezonefinder==5.2.0
 tinycss2==1.1.1
 tk==8.6.12

--- a/pangeo-notebook/conda-linux-64.lock
+++ b/pangeo-notebook/conda-linux-64.lock
@@ -365,7 +365,7 @@ https://conda.anaconda.org/conda-forge/linux-64/anyio-3.5.0-py39hf3d152e_0.tar.b
 https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py39hb9d737c_2.tar.bz2#76139de3552a2046135eb0b2d02a9c85
 https://conda.anaconda.org/conda-forge/linux-64/arrow-cpp-7.0.0-py39h965a45d_4_cpu.tar.bz2#b03b51c36476a6e0db7b0348e0b8389c
 https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.2-pyhd8ed1ab_0.tar.bz2#25e79f9a1133556671becbd65a170c78
-https://conda.anaconda.org/conda-forge/linux-64/av-9.1.1-py39hbd8a108_1.tar.bz2#5134ee232bf08dd32cac35528edc30e6
+https://conda.anaconda.org/conda-forge/linux-64/av-9.2.0-py39hbd8a108_0.tar.bz2#bfe4d864d2424c768345f1f478176eba
 https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2#c5b3edc62d6309088f4970b3eaaa65a6
 https://conda.anaconda.org/conda-forge/noarch/bleach-5.0.0-pyhd8ed1ab_0.tar.bz2#2a2ae7c56b8f72caba261363407b484a
 https://conda.anaconda.org/conda-forge/linux-64/bottleneck-1.3.4-py39hd257fcd_1.tar.bz2#d73b5da2a850eb047a358e97780e29d7

--- a/pangeo-notebook/conda-linux-64.lock
+++ b/pangeo-notebook/conda-linux-64.lock
@@ -3,7 +3,7 @@
 # input_hash: e73238190e41ff945c30d3c0b4ab612de3f37f1221d863ab403c204a851853cb
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/linux-64/gh-2.8.0-ha8f183a_0.tar.bz2#7817ecbfff4bf3bcfb357534c5a00b5e
-https://conda.anaconda.org/conda-forge/linux-64/git-lfs-3.1.2-ha770c72_0.tar.bz2#c606e9e8c43c75ff80f0bb13034e6b80
+https://conda.anaconda.org/conda-forge/linux-64/git-lfs-3.1.4-ha770c72_0.tar.bz2#1bd1d0f0bae6a3ed371d7c90b0d79510
 https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2#9a66894dfd07c4510beb6b3f9672ccc0
 https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
 https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2021.10.8-ha878542_0.tar.bz2#575611b8a84f45960e87722eeb51fa26
@@ -262,7 +262,7 @@ https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2#f
 https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2#5844808ffab9ebdb694585b50ba02a96
 https://conda.anaconda.org/conda-forge/noarch/toolz-0.11.2-pyhd8ed1ab_0.tar.bz2#f348d1590550371edfac5ed3c1d44f7e
 https://conda.anaconda.org/conda-forge/noarch/traitlets-5.1.1-pyhd8ed1ab_0.tar.bz2#a1bc9765ef9499760e88f568b3a6622c
-https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.2.0-pyha770c72_0.tar.bz2#0b04e3ee5a310a3bec598a04479e7fa3
+https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.2.0-pyha770c72_1.tar.bz2#f0f7e024f94e23d3bfee0ab777bf335a
 https://conda.anaconda.org/conda-forge/noarch/unidecode-1.3.4-pyhd8ed1ab_0.tar.bz2#6ee0ed0149b472fdf458e4fd18ea1596
 https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2#3563be4c5611a44210d9ba0c16113136
 https://conda.anaconda.org/conda-forge/noarch/webob-1.8.7-pyhd8ed1ab_0.tar.bz2#a8192f3585f341ea66c60c189580ac67
@@ -349,13 +349,13 @@ https://conda.anaconda.org/conda-forge/linux-64/rtree-1.0.0-py39hb102c33_1.tar.b
 https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.6-py39hb9d737c_1.tar.bz2#a0fabd69dd35bb24ec84d28dc01c3c5b
 https://conda.anaconda.org/conda-forge/linux-64/setuptools-60.10.0-py39hf3d152e_0.tar.bz2#1d5e7bd9ec2e75cd3b606c58d9e120e8
 https://conda.anaconda.org/conda-forge/linux-64/sniffio-1.2.0-py39hf3d152e_3.tar.bz2#e2cb114a39b27ef1687a0c2c3e793cf6
-https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.7.2-h1e4a385_0.tar.bz2#7ed84e0315e9d1b1620a881f1f7e22fc
+https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.8.0-h1e4a385_1.tar.bz2#3a50a4b46dbedbe495d8b3fa6ec2c27a
 https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.1.1-pyhd8ed1ab_0.tar.bz2#5d280406501e79dc7aa9c9ac31d25a80
 https://conda.anaconda.org/conda-forge/linux-64/tornado-6.1-py39hb9d737c_3.tar.bz2#5e13a2d214ed4184969df363a1aab420
 https://conda.anaconda.org/conda-forge/noarch/tqdm-4.64.0-pyhd8ed1ab_0.tar.bz2#6642233f341e1900d0c8e6eddb979c14
 https://conda.anaconda.org/conda-forge/noarch/traittypes-0.2.1-pyh9f0ad1d_2.tar.bz2#7d32ccb5334a6822c28af3e864550618
 https://conda.anaconda.org/conda-forge/noarch/trollsift-0.4.0-pyhd8ed1ab_0.tar.bz2#28417137108bfc7db0a5a87137ab7551
-https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.2.0-hd8ed1ab_0.tar.bz2#2f8145b0ba478dc1ac974ac1900d3b66
+https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.2.0-hd8ed1ab_1.tar.bz2#6d9d7480c5780514779967be2ee8b963
 https://conda.anaconda.org/conda-forge/linux-64/ujson-5.2.0-py39h5a03fae_1.tar.bz2#9827078f4b6c3af7c08517cda58bd1be
 https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-14.0.0-py39hb9d737c_1.tar.bz2#ef84376736d1e8a814ccb06d1d814e6f
 https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.14.0-py39hb9d737c_1.tar.bz2#f8a851de6463445ebf53161a4f41db93
@@ -429,7 +429,7 @@ https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2#cb83a3d6
 https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-1.4.35-py39hb9d737c_0.tar.bz2#aba3f9a2c924f9b91dbc45ed727b1985
 https://conda.anaconda.org/conda-forge/noarch/stack_data-0.2.0-pyhd8ed1ab_0.tar.bz2#8c0ce3e6bf18a0c810125aef58a2a6f3
 https://conda.anaconda.org/conda-forge/linux-64/terminado-0.13.3-py39hf3d152e_1.tar.bz2#bebf6da1adb04ed902ff335e61438a6e
-https://conda.anaconda.org/conda-forge/linux-64/tiledb-py-0.13.3-py39hcd6ad5b_0.tar.bz2#e16c64a2b6d8c79f1172314306b1a9c4
+https://conda.anaconda.org/conda-forge/linux-64/tiledb-py-0.14.0-py39h7d821a0_1.tar.bz2#613d20f7c121cbe8dc5ee18ad634c8ad
 https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.17.6-py39hf3d152e_1.tar.bz2#629569ca82cb91771b65fba986da69dd
 https://conda.anaconda.org/conda-forge/linux-64/yarl-1.7.2-py39hb9d737c_2.tar.bz2#f2f2df8a6238bf5e68c3aaf0e86e08d0
 https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.8.1-py39hb9d737c_1.tar.bz2#8d847048d7b3b3ace26e40731297e37f
@@ -447,7 +447,7 @@ https://conda.anaconda.org/conda-forge/linux-64/googleapis-common-protos-1.56.0-
 https://conda.anaconda.org/conda-forge/noarch/h5netcdf-1.0.0-pyhd8ed1ab_0.tar.bz2#b332c9d437d87810abd1285a4ae7c94b
 https://conda.anaconda.org/conda-forge/noarch/jupyter_telemetry-0.1.0-pyhd8ed1ab_1.tar.bz2#bb9ebdb6d5aa2622484aff1faceee181
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2#243f63592c8e449f40cd42eb5cf32f40
-https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.4.2-h8ff35cd_5.tar.bz2#b566ab30051e692541d0a8b7a2d70d58
+https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.4.2-hb785293_6.tar.bz2#32e7620fb49a6c4974e57825df9dba74
 https://conda.anaconda.org/conda-forge/noarch/marshmallow-oneofschema-3.0.1-pyhd8ed1ab_0.tar.bz2#4feef1f2c0f93b72161bb6c838813b30
 https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.5.1-py39h2fa2bec_0.tar.bz2#739c2c88c887da02e6f4b438bf258936
 https://conda.anaconda.org/conda-forge/linux-64/nb_conda_kernels-2.3.1-py39hf3d152e_1.tar.bz2#ef221076b7cacb498179b1eb3c527c6b
@@ -480,7 +480,7 @@ https://conda.anaconda.org/conda-forge/noarch/descartes-1.1.0-py_4.tar.bz2#32fa3
 https://conda.anaconda.org/conda-forge/linux-64/esmpy-8.2.0-mpi_mpich_py39h8bb458d_101.tar.bz2#347f324dd99dfb0b1479a466213b55bf
 https://conda.anaconda.org/conda-forge/noarch/fastapi-0.75.2-pyhd8ed1ab_0.tar.bz2#4f5576122e79718c6d614ed52cac0588
 https://conda.anaconda.org/conda-forge/noarch/ftfy-6.1.1-pyhd8ed1ab_0.tar.bz2#8112acb97be37967accbbe75436b62d7
-https://conda.anaconda.org/conda-forge/linux-64/gdal-3.4.2-py39hc691d54_5.tar.bz2#ce9771815bd0fde323a9b308e7f3e152
+https://conda.anaconda.org/conda-forge/linux-64/gdal-3.4.2-py39hc691d54_6.tar.bz2#98c29845bb963e073efbcc5140a55ca9
 https://conda.anaconda.org/conda-forge/linux-64/gtk2-2.24.33-h90689f9_2.tar.bz2#957a0255ab58aaf394a91725d73ab422
 https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.52.5-h0a9e6e8_3.tar.bz2#a08562889b985d021550e22443cf0fce
 https://conda.anaconda.org/conda-forge/noarch/nbclient-0.6.0-pyhd8ed1ab_0.tar.bz2#d71e4af52485f7e1b9919987ae24413c
@@ -552,13 +552,13 @@ https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-0.5.1-pyhd8ed
 https://conda.anaconda.org/conda-forge/noarch/intake-0.6.5-pyhd8ed1ab_0.tar.bz2#9b4be120fd2545abd086bfefda0fa0f6
 https://conda.anaconda.org/conda-forge/noarch/jupyter-resource-usage-0.6.1-pyhd8ed1ab_0.tar.bz2#a35cb988cd5b9b9b2d1c6179a8a86974
 https://conda.anaconda.org/conda-forge/noarch/jupyter-server-proxy-3.2.1-pyhd8ed1ab_0.tar.bz2#8fdfe5edf206bbfef250c830b5a72aff
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.12.0-pyhd8ed1ab_0.tar.bz2#62b14b14bbe75df451b0ee99d87df16f
+https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.13.0-pyhd8ed1ab_1.tar.bz2#ecead930bfd8c0f629c5b8bf5c1e3508
 https://conda.anaconda.org/conda-forge/noarch/metpy-1.3.0-pyhd8ed1ab_0.tar.bz2#abf4df8cafc944ae288416f395071bc0
 https://conda.anaconda.org/conda-forge/noarch/msal_extensions-0.3.1-pyhd8ed1ab_0.tar.bz2#6dd32d145f72c2f70ab13981da2eda82
 https://conda.anaconda.org/conda-forge/noarch/msrest-0.6.21-pyh44b312d_0.tar.bz2#1d2ea1f71147bd5ed5222a9f0d6df946
 https://conda.anaconda.org/conda-forge/noarch/nbconvert-6.5.0-pyhd8ed1ab_0.tar.bz2#156c180588e38b9f41758058824ec50f
 https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.1.0-pyhd8ed1ab_0.tar.bz2#3a8e2c7dcc674f2cb0784f1faba57055
-https://conda.anaconda.org/conda-forge/noarch/panel-0.12.7-pyhd8ed1ab_0.tar.bz2#1e0f7d14d996f17b14e9e482e4a01b4d
+https://conda.anaconda.org/conda-forge/noarch/panel-0.13.0-pyhd8ed1ab_0.tar.bz2#54cb4a5e8155c1ba91e7a09b7185b281
 https://conda.anaconda.org/conda-forge/linux-64/parcels-2.3.0-py39hf3d152e_2.tar.bz2#b88763a78ff9d0c3f314526b5890fb1a
 https://conda.anaconda.org/conda-forge/noarch/prefect-1.2.0-pyhd8ed1ab_0.tar.bz2#0ab92cfc39d6c67a548b30e0c1b2fcfb
 https://conda.anaconda.org/conda-forge/noarch/pyspectral-0.11.0-pyhd8ed1ab_0.tar.bz2#7ae8eb4d631745db9a654532e10608eb
@@ -587,7 +587,7 @@ https://conda.anaconda.org/conda-forge/noarch/intake-esm-2021.8.17-pyhd8ed1ab_0.
 https://conda.anaconda.org/conda-forge/noarch/intake-geopandas-0.4.0-pyhd8ed1ab_0.tar.bz2#5d6429a927d1ef3c0d26d81f5d7b31f0
 https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.6.0-pyhd8ed1ab_0.tar.bz2#3d2127b3aaa9193215c87ab9d92f6af0
 https://conda.anaconda.org/conda-forge/noarch/jupyter-panel-proxy-0.1.0-py_0.tar.bz2#80c21feab6100e287707c371c752adea
-https://conda.anaconda.org/conda-forge/noarch/notebook-6.4.10-pyha770c72_0.tar.bz2#7221a3cbd39e1a3101559e4508e54eae
+https://conda.anaconda.org/conda-forge/noarch/notebook-6.4.11-pyha770c72_0.tar.bz2#da25720a88aa3cbb3e16df740783da74
 https://conda.anaconda.org/conda-forge/noarch/satpy-0.36.0-pyhd8ed1ab_0.tar.bz2#33219d79dce152dc6db8501c7c8bc83c
 https://conda.anaconda.org/conda-forge/noarch/xskillscore-0.0.24-pyhd8ed1ab_0.tar.bz2#facc58b60c63642243013e12236e3ea7
 https://conda.anaconda.org/conda-forge/noarch/adlfs-2022.4.0-pyhd8ed1ab_0.tar.bz2#62bdd2bb3fa8091d4b8d7023d89d47ae

--- a/pangeo-notebook/environment.yml
+++ b/pangeo-notebook/environment.yml
@@ -100,3 +100,6 @@ dependencies:
  - xrft
  - xskillscore
  - zarr
+ - pip:
+   - gh-scoped-creds==4.0
+ 

--- a/pangeo-notebook/environment.yml
+++ b/pangeo-notebook/environment.yml
@@ -100,6 +100,3 @@ dependencies:
  - xrft
  - xskillscore
  - zarr
- - pip:
-   - gh-scoped-creds==4.0
- 

--- a/pangeo-notebook/packages.txt
+++ b/pangeo-notebook/packages.txt
@@ -167,7 +167,7 @@ gettext==0.19.8.1
 gflags==2.2.2
 gh==2.8.0
 giflib==5.2.1
-git-lfs==3.1.2
+git-lfs==3.1.4
 glog==0.6.0
 gmp==6.2.1
 gnutls==3.6.13
@@ -241,7 +241,7 @@ jupyterhub-base==2.2.2
 jupyterhub-singleuser==2.2.2
 jupyterlab==3.3.4
 jupyterlab_pygments==0.2.2
-jupyterlab_server==2.12.0
+jupyterlab_server==2.13.0
 jupyterlab_widgets==1.1.0
 jxrlib==1.1
 kealib==1.4.14
@@ -374,7 +374,7 @@ nettle==3.6
 networkx==2.8
 noise==1.2.2
 nomkl==1.0
-notebook==6.4.10
+notebook==6.4.11
 notebook-shim==0.1.0
 nspr==4.32
 nss==3.77
@@ -392,7 +392,7 @@ pamela==1.0.0
 pandas==1.4.2
 pandoc==2.18
 pandocfilters==1.5.0
-panel==0.12.7
+panel==0.13.0
 pangeo-dask==2022.04.18
 pangeo-notebook==2022.04.18
 pango==1.50.7
@@ -537,8 +537,8 @@ terminado==0.13.3
 text-unidecode==1.3
 threadpoolctl==3.1.0
 tifffile==2022.4.8
-tiledb==2.7.2
-tiledb-py==0.13.3
+tiledb==2.8.0
+tiledb-py==0.14.0
 timezonefinder==5.2.0
 tinycss2==1.1.1
 tk==8.6.12

--- a/pangeo-notebook/packages.txt
+++ b/pangeo-notebook/packages.txt
@@ -27,7 +27,7 @@ async-timeout==4.0.2
 async_generator==1.10
 atk-1.0==2.36.0
 attrs==21.4.0
-av==9.1.1
+av==9.2.0
 aws-c-cal==0.5.11
 aws-c-common==0.6.2
 aws-c-event-stream==0.2.7

--- a/pangeo-notebook/requirements.txt
+++ b/pangeo-notebook/requirements.txt
@@ -1,1 +1,1 @@
-gh-scoped-creds==4.0
+gh-scoped-creds==4.1

--- a/pangeo-notebook/requirements.txt
+++ b/pangeo-notebook/requirements.txt
@@ -1,0 +1,1 @@
+gh-scoped-creds==4.0


### PR DESCRIPTION
This lets you *safely* push to GitHub from a properly configured GitHub.

See https://blog.jupyter.org/securely-pushing-to-github-from-a-jupyterhub-3ee42dfdc54f
(draft blog post) for more information