### PR TITLE
Set nvidia specific env vars in ml-notebook

### DIFF
--- a/ml-notebook/Dockerfile
+++ b/ml-notebook/Dockerfile
@@ -3,3 +3,7 @@
 # files (such as conda-linux-64.lock, start) in this repo.
 # Refer to the base-image/Dockerfile for documentation.
 FROM pangeo/base-image:master
+
+# Required for nvidia drivers to work inside the image
+ENV PATH=${PATH}:/usr/local/nvidia/bin
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64

--- a/ml-notebook/Dockerfile
+++ b/ml-notebook/Dockerfile
@@ -4,6 +4,8 @@
 # Refer to the base-image/Dockerfile for documentation.
 FROM pangeo/base-image:master
 
-# Required for nvidia drivers to work inside the image
+# Required for nvidia drivers to work inside the image on GKE
+# No-ops on other platforms - Azure doesn't need these set.
+# Shouldn't negatively affect anyone, and makes life easier on GKE.
 ENV PATH=${PATH}:/usr/local/nvidia/bin
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64


### PR DESCRIPTION
These are required for `nvidia-smi` and generally anything that touches the GPU to
properly work on most containerized systems. We could set this at the hub level, but
this is cleaner and reduces workload for hub admins.