### PR TITLE
Jax with CUDA support

### DIFF
--- a/ml-notebook/environment.yml
+++ b/ml-notebook/environment.yml
@@ -5,7 +5,7 @@ channels:
  - ngam
  - conda-forge
 dependencies:
- - cudatoolkit=10
+ - cudatoolkit=11
  - tensorflow=2.7.0
- - jax=0.3.0
+ - jax=0.3
  - jaxlib==*=*cuda*

--- a/ml-notebook/environment.yml
+++ b/ml-notebook/environment.yml
@@ -2,9 +2,10 @@
 # by conda-lock. Only put things here that are not already in pangeo-notebook
 name: pangeo
 channels:
+ - ngam
  - conda-forge
 dependencies:
  - cudatoolkit=10
  - tensorflow=2.7.0
  - jax=0.3.0
- - jaxlib=0.1.75
+ - jaxlib==*=*cuda*


### PR DESCRIPTION
See https://github.com/pangeo-data/pangeo-docker-images/pull/325#issuecomment-1128068097

When I tried to condalock this, I got

```
generating lockfile for linux-64
Failed to parse json, Expecting value: line 1 column 1 (char 0)
Could not lock the environment for platform linux-64
    Command: ['/opt/miniconda3/envs/condalock/bin/mamba', 'create', '--prefix', '/var/folders/n8/63q49ms55wxcj_gfbtykwp5r0000gn/T/tmpxbvhi8ui/prefix', '--dry-run', '--json', '--override-channels', '--channel', 'ngam', '--channel', 'conda-forge', 'xarray_leaflet', 'geopandas', 'pystac', 'xesmf', 'xcape', 'nc-time-axis', 'adlfs', 'xrft', 'earthdata', 'rechunker', 'param!=1.11.0', 'xarray-spatial', 'zarr', 'scikit-image', 'nb_conda_kernels', 'timezonefinder', 'xskillscore', 'jupyter-resource-usage', 'pandas', 'satpy', 'ipywidgets', 'scikit-learn', 'matplotlib-base', 'panel', 'numcodecs', 'xarray', 'h5netcdf', 'anaconda::libopenblas', 'netcdf4', 'python=3.9*', 'erddapy', 'jaxlib==*=*cuda*', 'xarrayutils', 'nbstripout', 'pangeo-notebook=2022.05.10', 'pip=20', 'pyarrow', 'scipy', 'intake-xarray', 'parcels', 'ipytree', 'rasterio', 'rioxarray', 'awscli', 'cartopy >= 0.20.0', 'cudatoolkit=10', 'pystac-client', 'xpublish', 'geocube', 'pygeos', 'kerchunk', 'lz4', 'intake-esm', 'eofs', 'python-graphviz', 'geopy', 'gh', 'gh-scoped-creds', 'git-lfs', 'sparse', 'argopy', 'jax=0.3.0', 'intake-geopandas', 'xgcm', 'metpy', 'geoviews-core', 'intake-stac', 'rio-cogeo', 's3fs>0.5', 'pop-tools', 'bottleneck', 'esmpy', 'h5py', 'fsspec', 'jupyter-panel-proxy', 'dask-ml', 'hvplot', 'lxml', 'seaborn', 'ciso', 'stackstac', 'gsw', 'boto3', 'gcsfs', 'pycamhd', 'tensorflow=2.7.0', 'cfgrib', 'tiledb-py', 'nomkl', 'datashader', 'intake', 'ipyleaflet', 'python-gist', 'xmitgcm', 'fastjmd95', 'python-blosc', 'pydap', 'gcm_filters', 'prefect', 'cmip6_preprocessing', 'xhistogram', 'descartes', 'numpy', 'holoviews']
    STDOUT:
Encountered problems while solving.
Problem: nothing provides __glibc >=2.17 needed by jaxlib-0.3.7-cuda112py39h9c5d0a6_0
```

cc @ngam 