### PR TITLE
Bump base image to newer Ubuntu

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for base image of all pangeo images
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 # build file for pangeo images
 
 LABEL org.opencontainers.image.source=https://github.com/pangeo-data/pangeo-docker-images


### PR DESCRIPTION
It's time! I don't actually think we need to wait for 20.4.1 - I think that
is valid for desktop systems and VMs, but not for container images. 
Particularly, we don't use the subsysems that are the primary
reason for 'wait for first point release' - the kernel, filesystems and the desktop
environment.

Fixes #352