### PR TITLE
Add groff, dependency for awscli

### DIFF
--- a/ml-notebook/apt.txt
+++ b/ml-notebook/apt.txt
@@ -1,2 +1,3 @@
 git
+groff
 vim

--- a/pangeo-notebook/apt.txt
+++ b/pangeo-notebook/apt.txt
@@ -1,3 +1,4 @@
 git
-vim
+groff
 tree
+vim

--- a/pytorch-notebook/apt.txt
+++ b/pytorch-notebook/apt.txt
@@ -1,2 +1,3 @@
 git
+groff
 vim


### PR DESCRIPTION
`groff` is a declared dependency for the `awscli` as seen in
https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html.

Without `groff`, running `aws help` will lead to a failure.

Closes #216.

### Important review

Please review that it makes sense to add groff to all these `apt.txt` files (`.binder/`, `pangeo-notebook/`, `ml-notebook/`, `pytorch-notebook/`). I'm both confused about finding a `.binder` folder and its relevance, as well as considering that ml/pytorch somehow depends on the pangeo-notebook.