### PR TITLE
Fixes pangeo forge image to be functional in Apache Beam environment 

### DIFF
--- a/forge/Dockerfile
+++ b/forge/Dockerfile
@@ -24,3 +24,8 @@ FROM pangeo/base-image:${PANGEO_BASE_IMAGE_TAG}
 # The version used here *must* match the version of `apache-beam[gcp]` in the
 # accompanying `environment.yml` file
 COPY --from=apache/beam_python3.9_sdk:2.40.0 /opt/apache/beam/boot /opt/apache/beam/boot
+
+# Unfortunately, it looks like GCP DataFlow requires containers be run as root -
+# it mounts some folders into /var/opt/ and expects them to be writeable as root :(
+# This shouldn't affect Jupyter use cases as they often set uid explicitly anyway.
+USER root

--- a/forge/start
+++ b/forge/start
@@ -17,12 +17,17 @@ import os
 import sys
 
 # List is provided by running /usr/local/bin/boot, and finding
-# the ones marked as 'required'
+# the ones marked as 'required'.
 REQUIRED_BEAM_BOOT_PARAMS = [
-    '-id', '-control_endpoint', '-logging_endpoint',
-    '-artifact_endpoint', '-provision_endpoint'
+    'id', 'control_endpoint', 'logging_endpoint',
+    'artifact_endpoint', 'provision_endpoint'
 ]
-if all(x in sys.argv for x in REQUIRED_BEAM_BOOT_PARAMS):
+
+# Can't just use a simple existence check, as args can be passed in as
+# ["-id", "some-id"], ["-id=<some-id>"] or ["--id=<some-id>"]. So we
+# strip all preceeding -s, and check that *all* the required parameters
+# are passed in at least once
+if all(any(arg.lstrip('-').startswith(x) for arg in sys.argv) for x in REQUIRED_BEAM_BOOT_PARAMS):
     command = '/opt/apache/beam/boot'
 else:
     command = sys.argv[1]

--- a/forge/start
+++ b/forge/start
@@ -29,7 +29,11 @@ REQUIRED_BEAM_BOOT_PARAMS = [
 # are passed in at least once
 if all(any(arg.lstrip('-').startswith(x) for arg in sys.argv) for x in REQUIRED_BEAM_BOOT_PARAMS):
     command = '/opt/apache/beam/boot'
+    # exec's args need the command to be repeated, or most languages'
+    # commandline parsers (including go's) will break
+    args = [command] + sys.argv[1:]
 else:
     command = sys.argv[1]
+    args = sys.argv[1:]
 
-os.execvp(command, sys.argv[1:])
+os.execvp(command, args)

--- a/forge/start
+++ b/forge/start
@@ -20,7 +20,7 @@ import sys
 # the ones marked as 'required'
 REQUIRED_BEAM_BOOT_PARAMS = [
     '-id', '-control_endpoint', '-logging_endpoint',
-    'artifact_endpoint', 'provision_endpoint'
+    '-artifact_endpoint', '-provision_endpoint'
 ]
 if all(x in sys.argv for x in REQUIRED_BEAM_BOOT_PARAMS):
     command = '/opt/apache/beam/boot'

--- a/tests/test_forge.py
+++ b/tests/test_forge.py
@@ -30,7 +30,7 @@ def test_start_script():
     # Copied from ./forge/start
     boot_args = [
         '-id', '-control_endpoint', '-logging_endpoint',
-        'artifact_endpoint', 'provision_endpoint'
+        '-artifact_endpoint', '-provision_endpoint'
     ]
     # If the parameters that Apache beam passes to the boot program are
     # detected, it should instead call the apache beam boot program! This is

--- a/tests/test_forge.py
+++ b/tests/test_forge.py
@@ -39,6 +39,6 @@ def test_start_script():
     # boot complains about seems to be non deterministic, so let's use a bit of
     # a fuzzy regex to check this works.
     assert re.search(
-        r'No(.*)provided.\n$',
+        r'flag needs an argument:',
         subprocess.run(['/srv/start'] + boot_args, capture_output=True).stderr.decode()
     )


### PR DESCRIPTION
- Fiddle with the `start` script, so it launches the beam boot binary correctly. Had to
  fix how we were detecting the boot binary being called, as well as how we were calling
  `exec` - args' first param needs to be the name of the command for commandline parsing
  to work properl
- GCP DataFlow unfortunately expects the container to run as root - it mounts some directories
   under `/var/opt` as root and expects the launched process to be able to read / write to it :( This
   we should raise upstream and find some way to fix - but in the meantime, the forge image now
   defaults to root. This shouldn't affect Jupyter use cases though, as we set the uid explicitly and
   ignore what the image says most of the time.