### PR TITLE
Switch to buildx for github actions

### DIFF
--- a/.github/workflows/Binder.yml
+++ b/.github/workflows/Binder.yml
@@ -3,6 +3,10 @@
 name: Binder
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # NOTE: look into doing this for pangeo-binders too!
   Create-MyBinderOrg-Cache:

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -30,29 +30,33 @@ jobs:
         CALVER="$( date -u '+%Y.%m.%d' )"
         SHA7="${GITHUB_SHA::7}"
         DOCKER_TAG=$SHA7
-        IMAGE_SPEC="${DOCKER_ORG}/${{ env.IMAGE }}:${DOCKER_TAG}"
         echo "DOCKER_TAG=${DOCKER_TAG}" >> $GITHUB_ENV
-        echo "IMAGE_SPEC=${IMAGE_SPEC}" >> $GITHUB_ENV
 
-    - name: Build and Publish to DockerHub
-      uses: elgohr/Publish-Docker-Github-Action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
       with:
-        name: ${{env.DOCKER_ORG}}/${{ env.IMAGE }}
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-        workdir: ${{ env.IMAGE }}
-        tags: "master, ${{env.DOCKER_TAG}}"
-    
-    - name: Also Push To quay.io
-      id: push-to-quay
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{env.DOCKER_ORG}}/${{ env.IMAGE }}
-        tags:  master ${{env.DOCKER_TAG}}
-        registry: quay.io
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
 
+    - name: Login to Quay.io
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.QUAY_USER }}
+        password: ${{ secrets.QUAY_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        context: ${{ matrix.IMAGE }}
+        push: true
+        tags: |
+          ${{env.DOCKER_ORG}}/${{ env.IMAGE }}:master
+          ${{env.DOCKER_ORG}}/${{ env.IMAGE }}:${{env.DOCKER_TAG}}
+          quay.io/${{env.DOCKER_ORG}}/${{ env.IMAGE }}:master
+          quay.io/${{env.DOCKER_ORG}}/${{ env.IMAGE }}:${{env.DOCKER_TAG}}
 
   matrix-build:
     needs: base-image
@@ -70,9 +74,7 @@ jobs:
       run: |
         SHA7="${GITHUB_SHA::7}"
         DOCKER_TAG=$SHA7
-        IMAGE_SPEC="${DOCKER_ORG}/${{ matrix.IMAGE }}:${DOCKER_TAG}"
         echo "DOCKER_TAG=${DOCKER_TAG}" >> $GITHUB_ENV
-        echo "IMAGE_SPEC=${IMAGE_SPEC}" >> $GITHUB_ENV
 
     # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
     - name: Free up disk space

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v3
       with:
-        context: ${{ matrix.IMAGE }}
+        context: ${{ env.IMAGE }}
         push: true
         tags: |
           ${{env.DOCKER_ORG}}/${{ env.IMAGE }}:master

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -83,27 +83,31 @@ jobs:
         sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
         df -h
 
-    - name: Build and Publish to DockerHub
-      uses: elgohr/Publish-Docker-Github-Action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
       with:
-        name: ${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-        workdir: ${{ matrix.IMAGE }}
-        tags: "master, ${{env.DOCKER_TAG}}"
 
-    - name: Also Push To quay.io
-      id: push-to-quay
-      uses: redhat-actions/push-to-registry@v2
+    - name: Login to Quay.io
+      uses: docker/login-action@v2
       with:
-        image: ${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}
-        tags:  master ${{env.DOCKER_TAG}}
-        registry: quay.io
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
+        username: ${{ secrets.QUAY_USER }}
+        password: ${{ secrets.QUAY_TOKEN }}
 
-    - name: Print image url
-      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        context: ${{ matrix.IMAGE }}
+        push: true
+        tags: |
+          ${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}:master
+          ${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}:${{env.DOCKER_TAG}}
+          quay.io/${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}:master
+          quay.io/${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}:${{env.DOCKER_TAG}}
 
     - name: Export Full Conda Environment
       run: |

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -44,6 +44,7 @@ jobs:
     - name: Login to Quay.io
       uses: docker/login-action@v2
       with:
+        registry: quay.io
         username: ${{ secrets.QUAY_USER }}
         password: ${{ secrets.QUAY_TOKEN }}
 
@@ -97,6 +98,7 @@ jobs:
     - name: Login to Quay.io
       uses: docker/login-action@v2
       with:
+        registry: quay.io
         username: ${{ secrets.QUAY_USER }}
         password: ${{ secrets.QUAY_TOKEN }}
 

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -51,6 +51,7 @@ jobs:
     - name: Login to Quay.io
       uses: docker/login-action@v2
       with:
+        registry: quay.io
         username: ${{ secrets.QUAY_USER }}
         password: ${{ secrets.QUAY_TOKEN }}
 

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -39,27 +39,38 @@ jobs:
         echo "SHA7=${SHA7}" >> $GITHUB_ENV
         echo "TAG=${TAG}" >> $GITHUB_ENV
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Login to Quay.io
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.QUAY_USER }}
+        password: ${{ secrets.QUAY_TOKEN }}
+
     - name: Pull Image for Corresponding GitHub Commit
       run: |
         docker pull ${DOCKER_ORG}/${{ matrix.IMAGE }}:${SHA7}
 
-    - name: Authenticate with DockerHub
-      run: |
-        echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-
-    - name: Retag and Push Image to DockerHub
+    - name: Retag Images
       run: |
         docker tag ${DOCKER_ORG}/${{ matrix.IMAGE }}:${SHA7} ${DOCKER_ORG}/${{ matrix.IMAGE }}:latest
         docker tag ${DOCKER_ORG}/${{ matrix.IMAGE }}:${SHA7} ${DOCKER_ORG}/${{ matrix.IMAGE }}:${TAG}
+        docker tag ${DOCKER_ORG}/${{ matrix.IMAGE }}:${SHA7} quay.io/${DOCKER_ORG}/${{ matrix.IMAGE }}:latest
+        docker tag ${DOCKER_ORG}/${{ matrix.IMAGE }}:${SHA7} quay.io/${DOCKER_ORG}/${{ matrix.IMAGE }}:${TAG}
+
+    - name: Push Tags to Docker Hub
+      run: |
         docker push ${DOCKER_ORG}/${{ matrix.IMAGE }}:latest
         docker push ${DOCKER_ORG}/${{ matrix.IMAGE }}:${TAG}
 
-    - name: Also Push To quay.io
-      id: push-to-quay
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}
-        tags:  latest ${{env.TAG}}
-        registry: quay.io
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
+    - name: Push Tags To Quay.io
+      run: |
+        docker push quay.io/${DOCKER_ORG}/${{ matrix.IMAGE }}:latest
+        docker push quay.io/${DOCKER_ORG}/${{ matrix.IMAGE }}:${TAG}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -17,20 +17,21 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v3
 
-    - name: Build Base Image
-      run: |
-        cd base-image
-        docker build -t ${DOCKER_ORG}/base-image:PR .
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
 
-    - name: Save Docker Image
-      run: |
-        docker save ${DOCKER_ORG}/base-image:PR | gzip > base-image.tar.gz
+    - name: Build and export
+      uses: docker/build-push-action@v3
+      with:
+        context: base-image
+        tags: base-image:PR
+        outputs: type=docker,dest=/tmp/base-image.tar
 
-    - name: Upload Base Image
+    - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:
         name: base-image
-        path: base-image.tar.gz
+        path: /tmp/base-image.tar
 
   matrix-build:
     needs: base-image
@@ -44,20 +45,30 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v3
 
-    - name: Download Base Docker Image
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    
+    - name: Download artifact
       uses: actions/download-artifact@v3
       with:
         name: base-image
-        path: ./artifact
-
-    - name: Load Docker Image
+        path: /tmp
+      
+    - name: Load Base Image
       run: |
-        docker load < ./artifact/base-image.tar.gz
+        docker load --input /tmp/base-image.tar
+        docker image ls -a
 
-    - name: Build Image
-      run: |
-        cd ${{ matrix.IMAGE }}
-        docker build --build-arg  PANGEO_BASE_IMAGE_TAG=PR -t ${DOCKER_ORG}/${{ matrix.IMAGE }}:PR .
+    - name: Build Only
+      uses: docker/build-push-action@v3
+      with:
+        context: ${{ env.IMAGE }}
+        push: false
+        load: true
+        tags: |
+          ${{env.DOCKER_ORG}}/${{ env.IMAGE }}:PR
+        build-args: | 
+          PANGEO_BASE_IMAGE_TAG=PR
 
     - name: Report Image Size and Conda Packages
       run: |

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,6 +1,10 @@
 # Any PR opened, build images and run tests
 name: Test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -11,70 +15,53 @@ env:
   GITHUB_REF: ${{ github.ref }}
 
 jobs:
-  base-image:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-
-    - name: Build and export
-      uses: docker/build-push-action@v3
-      with:
-        context: base-image
-        tags: base-image:PR
-        outputs: type=docker,dest=/tmp/base-image.tar
-
-    - name: Upload artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: base-image
-        path: /tmp/base-image.tar
-
   matrix-build:
-    needs: base-image
     strategy:
       fail-fast: false
       matrix:
         IMAGE: [base-notebook, pangeo-notebook, ml-notebook, pytorch-notebook, forge]
     name: ${{ matrix.IMAGE }}
     runs-on: ubuntu-latest
+    services:
+      # https://github.com/docker/build-push-action/blob/master/docs/advanced/local-registry.md#local-registry
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-    
-    - name: Download artifact
-      uses: actions/download-artifact@v3
       with:
-        name: base-image
-        path: /tmp
-      
-    - name: Load Base Image
-      run: |
-        docker load --input /tmp/base-image.tar
-        docker image ls -a
+        driver-opts: network=host
+    
+    - name: Build base-image
+      uses: docker/build-push-action@v3
+      with:
+        context: base-image
+        tags: localhost:5000/pangeo/base-image:PR
+        push: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Build Only
       uses: docker/build-push-action@v3
       with:
-        context: ${{ env.IMAGE }}
-        push: false
-        load: true
-        tags: |
-          ${{env.DOCKER_ORG}}/${{ env.IMAGE }}:PR
-        build-args: | 
-          PANGEO_BASE_IMAGE_TAG=PR
+        context: ${{ matrix.IMAGE }}
+        push: true
+        tags: localhost:5000/${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}:PR
+        build-args: PANGEO_BASE_IMAGE_TAG=PR
+        build-contexts: |
+          pangeo/base-image:PR=docker-image://localhost:5000/pangeo/base-image:PR
 
     - name: Report Image Size and Conda Packages
       run: |
         docker images
-        docker run ${DOCKER_ORG}/${{ matrix.IMAGE }}:PR conda list --export
+        docker run localhost:5000/${DOCKER_ORG}/${{ matrix.IMAGE }}:PR conda list --export
 
     - name: Test Image
       run: |
-        docker run -u 1000 -w /srv/test -v $PWD:/srv/test ${DOCKER_ORG}/${{ matrix.IMAGE }}:PR ./run_tests.sh ${{ matrix.IMAGE }}
+        docker run -u 1000 -w /srv/test -v $PWD:/srv/test localhost:5000/${DOCKER_ORG}/${{ matrix.IMAGE }}:PR ./run_tests.sh ${{ matrix.IMAGE }}


### PR DESCRIPTION
* Switch to docker github actions such as (docker/build-push-action) that are more flexible for newer buildkit options (#357)
* Use only docker, not docker and podman for quay.io to speed up CI (fixes https://github.com/pangeo-data/pangeo-docker-images/issues/121#issuecomment-1279389501 
* Cancel concurrent Binder and Test workflows for PRs if multiple commits are made
