### PR TITLE
Set TZ environment variable required for prefect

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -57,6 +57,9 @@ RUN echo "Installing Apt-get packages..." \
     && apt-get install -y apt-utils wget zip tzdata > /dev/null \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Add TZ configuration - https://github.com/PrefectHQ/prefect/issues/3061
+ENV TZ UTC
 # ========================
 
 USER ${NB_USER}


### PR DESCRIPTION
We recently ran into the same problem encountered in https://github.com/PrefectHQ/prefect/issues/3061 / https://github.com/pangeo-data/pangeo-docker-images/pull/183 and https://github.com/pangeo-data/pangeo-docker-images/issues/125. This sets the TZ env variable so that prefect can be used with Pangeo docker images without any extra configuration needed.