### PR TITLE
Free up disk space on Pull Request Test CI

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -33,11 +33,20 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v3
 
+    # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+    - name: Free up disk space
+      run: |
+        df -h
+        docker image ls
+        sudo apt clean
+        sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+        df -h
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
       with:
         driver-opts: network=host
-    
+
     - name: Build base-image
       uses: docker/build-push-action@v3
       with:


### PR DESCRIPTION
Delete unused folders on the GitHub Actions runner to free up disk space for the docker build and test steps. Copied from 35f0c9a4ef31bcefe3ca0b7a8b6eb95553b2e02a.

Should help to prevent out of disk space errors on the pytorch-notebook test step, e.g. at https://github.com/pangeo-data/pangeo-docker-images/pull/475#issuecomment-1652832996