### PR TITLE
Bump conda-lock to 2.5, and increase locking timeout to 45min

### DIFF
--- a/.github/workflows/CondaLock.yml
+++ b/.github/workflows/CondaLock.yml
@@ -14,7 +14,7 @@ jobs:
         IMAGE: [base-notebook, pangeo-notebook, ml-notebook, pytorch-notebook]
     name: ${{ matrix.IMAGE }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     defaults:
       run:
         shell: bash -el {0}

--- a/environment-condalock.yml
+++ b/environment-condalock.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - python=3.11
-  - conda-lock=2.3
+  - conda-lock>=2.5
   - conda>=23.3.0
   - mamba=1

--- a/environment-condalock.yml
+++ b/environment-condalock.yml
@@ -4,5 +4,5 @@ channels:
 dependencies:
   - python=3.11
   - conda-lock>=2.5
-  - conda>=23.3.0
+  - conda>=24.5.0
   - mamba=1


### PR DESCRIPTION
Some updates cherry-picked from #514 to enable the CUDA upgrade from 11.8 to 12.0.

The 45min timeout might be a bit too generous, I can reduce it down to 30min or something after seeing what is actually required in #514 to lock the `pytorch-notebook` environment.