### PR TITLE
Increase conda-lock timeout to 3 hours

### DIFF
--- a/.github/workflows/CondaLock.yml
+++ b/.github/workflows/CondaLock.yml
@@ -14,7 +14,7 @@ jobs:
         IMAGE: [base-notebook, pangeo-notebook, ml-notebook, pytorch-notebook]
     name: ${{ matrix.IMAGE }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 180
     defaults:
       run:
         shell: bash -el {0}


### PR DESCRIPTION
Giving more time for conda-lock to solve the pytorch-notebook environment.

To help with https://github.com/pangeo-data/pangeo-docker-images/pull/545#issuecomment-2116033743 and https://github.com/pangeo-data/pangeo-docker-images/pull/514. Supersedes https://github.com/pangeo-data/pangeo-docker-images/pull/546