### PR TITLE
Set dockerfile syntax version 

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Dockerfile for base image of all pangeo images
 FROM ubuntu:22.04
 # build file for pangeo images
@@ -59,7 +60,7 @@ RUN echo "Installing Apt-get packages..." \
     && rm -rf /var/lib/apt/lists/*
 
 # Add TZ configuration - https://github.com/PrefectHQ/prefect/issues/3061
-ENV TZ UTC
+ENV TZ=UTC
 # ========================
 
 USER ${NB_USER}


### PR DESCRIPTION
Small change to test multiarch builds (following #399)

(I thought merging 399 would've pushed a multiarch image but it ran the existing 'Build' workflow on the master branch rather than the new one with QEMU https://github.com/pangeo-data/pangeo-docker-images/actions/runs/9706168740/job/26789540941)