### PR TITLE
Publish CalVer tags for linux/arm64 platform builds

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -17,6 +17,15 @@ jobs:
       fail-fast: false
       matrix:
         IMAGE: [base-image, base-notebook, pangeo-notebook, ml-notebook, pytorch-notebook]
+        platform: [linux/amd64]
+      # Extra CPU architectures for specific images
+      include:
+        - IMAGE: "base-image"
+          platform: "linux/arm64"
+        - IMAGE: "base-notebook"
+          platform: "linux/arm64"
+        - IMAGE: "pangeo-notebook"
+          platform: "linux/arm64"
     name: ${{ matrix.IMAGE }}
     runs-on: ubuntu-latest
     steps:
@@ -57,7 +66,7 @@ jobs:
 
     - name: Pull Image for Corresponding GitHub Commit
       run: |
-        docker pull ${DOCKER_ORG}/${{ matrix.IMAGE }}:${SHA7}
+        docker pull --platform ${{ matrix.platform }} ${DOCKER_ORG}/${{ matrix.IMAGE }}:${SHA7}
 
     - name: Retag Images
       run: |
@@ -68,10 +77,10 @@ jobs:
 
     - name: Push Tags to Docker Hub
       run: |
-        docker push ${DOCKER_ORG}/${{ matrix.IMAGE }}:latest
-        docker push ${DOCKER_ORG}/${{ matrix.IMAGE }}:${TAG}
+        docker push --platform ${{ matrix.platform }} ${DOCKER_ORG}/${{ matrix.IMAGE }}:latest
+        docker push --platform ${{ matrix.platform }} ${DOCKER_ORG}/${{ matrix.IMAGE }}:${TAG}
 
     - name: Push Tags To Quay.io
       run: |
-        docker push quay.io/${DOCKER_ORG}/${{ matrix.IMAGE }}:latest
-        docker push quay.io/${DOCKER_ORG}/${{ matrix.IMAGE }}:${TAG}
+        docker push --platform ${{ matrix.platform }} quay.io/${DOCKER_ORG}/${{ matrix.IMAGE }}:latest
+        docker push --platform ${{ matrix.platform }} quay.io/${DOCKER_ORG}/${{ matrix.IMAGE }}:${TAG}


### PR DESCRIPTION
The `base-image`, `base-notebook` and `pangeo-notebook` Docker images only had linux/amd64 platform available on the latest and CalVer tags (see e.g. [`pangeo-notebook:2024.06.28`](https://hub.docker.com/layers/pangeo/pangeo-notebook/2024.06.28/images/sha256-48c57426f0d907fec00010f5e2aa54a190f72cdd84fb6413fd76733a323d295a?context=explore)), whereas the master tag has both `linux/amd64` and `linux/arm64`:

![image](https://github.com/pangeo-data/pangeo-docker-images/assets/23487320/caa1c661-1725-4a20-90f6-2b7a777839d8)

Need to use the `--platform` flag when doing `docker pull` or `docker push`, so that the linux/arm64 images will be made available for `latest` and Calver tags.

Patches #399