### PR TITLE
Add ppc64le builds

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -55,7 +55,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: ${{ env.IMAGE }}
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64,linux/arm64,linux/ppc64le
         push: true
         tags: |
           ${{env.DOCKER_ORG}}/${{ env.IMAGE }}:master
@@ -114,7 +114,7 @@ jobs:
       with:
         context: ${{ matrix.IMAGE }}
         push: true
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64,linux/arm64,linux/ppc64le
         tags: |
           ${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}:master
           ${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}:${{env.DOCKER_TAG}}

--- a/.github/workflows/CondaLock.yml
+++ b/.github/workflows/CondaLock.yml
@@ -39,9 +39,9 @@ jobs:
         run: |
           cd ${{ matrix.IMAGE }}
           if [ ${{ matrix.IMAGE }} = "base-notebook" ]; then
-            conda-lock lock -p linux-64 -p linux-aarch64 -p osx-64 -p osx-arm64
+            conda-lock lock -p linux-64 -p linux-aarch64 -p linux-ppc64le -p osx-64 -p osx-arm64
           elif [ ${{ matrix.IMAGE }} = "pangeo-notebook" ]; then
-            conda-lock lock -f environment.yml -f ../base-notebook/environment.yml -p linux-64 -p linux-aarch64 -p osx-64 -p osx-arm64
+            conda-lock lock -f environment.yml -f ../base-notebook/environment.yml -p linux-64 -p linux-aarch64 -p linux-ppc64le -p osx-64 -p osx-arm64
           else
             # Linux-64 ONLY
             conda-lock lock -f environment.yml -f ../pangeo-notebook/environment.yml -f ../base-notebook/environment.yml -p linux-64

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -54,7 +54,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: base-image
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64,linux/arm64,linux/ppc64le
         tags: localhost:5000/pangeo/base-image:PR
         push: true
         cache-from: type=gha
@@ -64,7 +64,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: ${{ matrix.IMAGE }}
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64,linux/arm64,linux/ppc64le
         push: true
         tags: localhost:5000/${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}:PR
         build-args: PANGEO_BASE_IMAGE_TAG=PR

--- a/Makefile
+++ b/Makefile
@@ -6,24 +6,24 @@ TESTDIR=/srv/test
 .PHONY: base-image
 base-image :
 	cd base-image ; \
-	docker build -t pangeo/base-image:master --progress=plain --platform linux/amd64,linux/arm64 .
+	docker build -t pangeo/base-image:master --progress=plain --platform linux/amd64,linux/arm64,linux/ppc64le .
 
 .PHONY: base-notebook
 base-notebook : base-image
 	cd base-notebook ; \
-	conda-lock lock -p linux-64 -p linux-aarch64 -p osx-64 -p osx-arm64; \
+	conda-lock lock -p linux-64 -p linux-aarch64 -p linux-ppc64le -p osx-64 -p osx-arm64; \
 	conda-lock render -k explicit -p linux-64; \
 	../generate-packages-list.py conda-linux-64.lock > packages.txt; \
-	docker build -t pangeo/base-notebook:master . --progress=plain --platform linux/amd64,linux/arm64 ; \
+	docker build -t pangeo/base-notebook:master . --progress=plain --platform linux/amd64,linux/arm64,linux/ppc64le ; \
 	docker run -w $(TESTDIR) -v $(PWD):$(TESTDIR) pangeo/base-notebook:master ./run_tests.sh base-notebook
 
 .PHONY: pangeo-notebook
 pangeo-notebook : base-image
 	cd pangeo-notebook ; \
-	conda-lock lock -f environment.yml -f ../base-notebook/environment.yml -p linux-64 -p linux-aarch64 -p osx-64 -p osx-arm64; \
+	conda-lock lock -f environment.yml -f ../base-notebook/environment.yml -p linux-64 -p linux-aarch64 -p linux-ppc64le -p osx-64 -p osx-arm64; \
 	conda-lock render -k explicit -p linux-64; \
 	../generate-packages-list.py conda-linux-64.lock > packages.txt; \
-	docker build -t pangeo/pangeo-notebook:master . --progress=plain --platform linux/amd64,linux/arm64 ; \
+	docker build -t pangeo/pangeo-notebook:master . --progress=plain --platform linux/amd64,linux/arm64,linux/ppc64le ; \
 	docker run -w $(TESTDIR) -v $(PWD):$(TESTDIR) pangeo/pangeo-notebook:master ./run_tests.sh pangeo-notebook
 
 .PHONY: ml-notebook


### PR DESCRIPTION
Adding linux/ppc64le  builds for base-image, base-notebook and pangeo-notebook.

Resolves https://github.com/pangeo-data/pangeo-docker-images/issues/396#issue-1413182376