### PR TITLE
Feat: Add an onbuild install script step

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -184,6 +184,28 @@ ONBUILD RUN echo "Checking for pip 'requirements.txt'..." \
         ${NB_PYTHON_PREFIX}/bin/pip install --no-cache -r requirements.txt \
         ; fi
 
+ONBUILD USER root
+
+ONBUILD RUN  echo "Copy 'layer-cleanup'..." \
+        ; [ -d binder ] && cd binder \
+        ; [ -d .binder ] && cd .binder \
+        ; pwd; ls \
+        ; cp resources/layer-cleanup.sh /usr/local/bin/ \
+        ; chmod +x /usr/local/bin/layer-cleanup.sh
+
+ONBUILD RUN echo "Executing install scripts..." \
+        ; [ -d binder ] && cd binder \
+        ; [ -d .binder ] && cd .binder \
+        ; for script in $(find "resources" -type f -name "install.sh"); do \
+                chmod +x "$script"; \
+                echo "Executing $script"; \
+                bash "$script"; \
+                layer-cleanup.sh; \
+                chown -R ${NB_USER}:${NB_USER} ${HOME}; \
+        done
+
+ONBUILD USER ${NB_USER}
+
 # If a postBuild file exists, run it!
 # After it's done, we try to remove any possible cruft commands there
 # leave behind under $HOME - particularly stuff that jupyterlab extensions

--- a/base-notebook/resources/layer-cleanup.sh
+++ b/base-notebook/resources/layer-cleanup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2024 CS GROUP - https://www.csgroup.eu
+# All rights reserved
+# This file is provided under MIT license. See LICENSE file.
+
+apt-get autoclean --yes
+apt-get autoremove --yes
+
+rm -rf /var/lib/apt/lists/*
+rm -rf /etc/apt/sources.list.d/*
+rm -rf /usr/local/src/*
+
+rm -rf /var/cache/apt/*
+rm -rf /root/.cache/*
+# including /root/.cache/pip
+rm -rf /usr/local/share/.cache/*
+# including /usr/local/share/.cache/yarn
+
+if [ -x "$(command -v npm)" ]; then
+    npm cache clean --force
+    rm -rf /root/.npm/*
+    rm -rf /root/.node-gyp/*
+    rm -rf /usr/local/share/jupyter/lab/staging/node_modules/*
+    rm -rf /opt/*/node_modules/*
+fi
+
+rm -rf /tmp/* /var/tmp/*
+
+echo "Layer cleaned"
+
+exit 0

--- a/ml-notebook/resources/layer-cleanup.sh
+++ b/ml-notebook/resources/layer-cleanup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2024 CS GROUP - https://www.csgroup.eu
+# All rights reserved
+# This file is provided under MIT license. See LICENSE file.
+
+apt-get autoclean --yes
+apt-get autoremove --yes
+
+rm -rf /var/lib/apt/lists/*
+rm -rf /etc/apt/sources.list.d/*
+rm -rf /usr/local/src/*
+
+rm -rf /var/cache/apt/*
+rm -rf /root/.cache/*
+# including /root/.cache/pip
+rm -rf /usr/local/share/.cache/*
+# including /usr/local/share/.cache/yarn
+
+if [ -x "$(command -v npm)" ]; then
+    npm cache clean --force
+    rm -rf /root/.npm/*
+    rm -rf /root/.node-gyp/*
+    rm -rf /usr/local/share/jupyter/lab/staging/node_modules/*
+    rm -rf /opt/*/node_modules/*
+fi
+
+rm -rf /tmp/* /var/tmp/*
+
+echo "Layer cleaned"
+
+exit 0

--- a/pangeo-notebook/resources/layer-cleanup.sh
+++ b/pangeo-notebook/resources/layer-cleanup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2024 CS GROUP - https://www.csgroup.eu
+# All rights reserved
+# This file is provided under MIT license. See LICENSE file.
+
+apt-get autoclean --yes
+apt-get autoremove --yes
+
+rm -rf /var/lib/apt/lists/*
+rm -rf /etc/apt/sources.list.d/*
+rm -rf /usr/local/src/*
+
+rm -rf /var/cache/apt/*
+rm -rf /root/.cache/*
+# including /root/.cache/pip
+rm -rf /usr/local/share/.cache/*
+# including /usr/local/share/.cache/yarn
+
+if [ -x "$(command -v npm)" ]; then
+    npm cache clean --force
+    rm -rf /root/.npm/*
+    rm -rf /root/.node-gyp/*
+    rm -rf /usr/local/share/jupyter/lab/staging/node_modules/*
+    rm -rf /opt/*/node_modules/*
+fi
+
+rm -rf /tmp/* /var/tmp/*
+
+echo "Layer cleaned"
+
+exit 0

--- a/pytorch-notebook/resources/layer-cleanup.sh
+++ b/pytorch-notebook/resources/layer-cleanup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2024 CS GROUP - https://www.csgroup.eu
+# All rights reserved
+# This file is provided under MIT license. See LICENSE file.
+
+apt-get autoclean --yes
+apt-get autoremove --yes
+
+rm -rf /var/lib/apt/lists/*
+rm -rf /etc/apt/sources.list.d/*
+rm -rf /usr/local/src/*
+
+rm -rf /var/cache/apt/*
+rm -rf /root/.cache/*
+# including /root/.cache/pip
+rm -rf /usr/local/share/.cache/*
+# including /usr/local/share/.cache/yarn
+
+if [ -x "$(command -v npm)" ]; then
+    npm cache clean --force
+    rm -rf /root/.npm/*
+    rm -rf /root/.node-gyp/*
+    rm -rf /usr/local/share/jupyter/lab/staging/node_modules/*
+    rm -rf /opt/*/node_modules/*
+fi
+
+rm -rf /tmp/* /var/tmp/*
+
+echo "Layer cleaned"
+
+exit 0


### PR DESCRIPTION
Add an onbuild step to install application (ex. novnc). Also add a clean up script after installation.  
Necessary for #597 and #598 to work.