### PR TITLE
Initialize cuda-notebook Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for convenience, (doesn't look for command outputs)
 .PHONY: all
-all: base-image base-notebook pangeo-notebook ml-notebook pytorch-notebook
+all: base-image base-notebook pangeo-notebook ml-notebook pytorch-notebook cuda-notebook
 TESTDIR=/srv/test
 
 .PHONY: base-image
@@ -43,3 +43,8 @@ pytorch-notebook : base-image
 	../generate-packages-list.py conda-linux-64.lock > packages.txt; \
 	docker build -t pangeo/pytorch-notebook:master . ; \
 	docker run -w $(TESTDIR) -v $(PWD):$(TESTDIR) pangeo/pytorch-notebook:master ./run_tests.sh pytorch-notebook
+
+.PHONY: cuda-notebook
+cuda-notebook :
+	cd cuda-notebook ; \
+	docker build -t pangeo/cuda-notebook:master --progress=plain --platform linux/amd64 .

--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ More details can be found in [our documentation](https://pangeo-docker-images.re
 
 Images are hosted on [DockerHub](https://hub.docker.com/u/pangeo) and on [Quay.io](https://quay.io/organization/pangeo)
 
-| Image           | Description                                   |  Size | Pulls |
+| Image           | Description                                   | Size         | Pulls       |
 |-----------------|-----------------------------------------------|--------------|-------------|
 | base-image      | Foundational Dockerfile for builds            | ![](https://img.shields.io/docker/image-size/pangeo/base-image?sort=date) | ![](https://img.shields.io/docker/pulls/pangeo/base-image?sort=date)
 | [base-notebook](base-notebook/packages.txt) | minimally functional image for pangeo hubs | ![](https://img.shields.io/docker/image-size/pangeo/base-notebook?sort=date) | ![](https://img.shields.io/docker/pulls/pangeo/base-notebook?sort=date)
 | [pangeo-notebook](pangeo-notebook/packages.txt) | base-notebook + core earth science analysis packages | ![](https://img.shields.io/docker/image-size/pangeo/pangeo-notebook?sort=date) | ![](https://img.shields.io/docker/pulls/pangeo/pangeo-notebook?sort=date)
 | [pytorch-notebook](pytorch-notebook/packages.txt) | pangeo-notebook + GPU-enabled pytorch | ![](https://img.shields.io/docker/image-size/pangeo/pytorch-notebook?sort=date) | ![](https://img.shields.io/docker/pulls/pangeo/pytorch-notebook?sort=date)
 | [ml-notebook](ml-notebook/packages.txt) | pangeo-notebook + GPU-enabled tensorflow2 | ![](https://img.shields.io/docker/image-size/pangeo/ml-notebook?sort=date) | ![](https://img.shields.io/docker/pulls/pangeo/ml-notebook?sort=date)
+| cuda-notebook   | Foundational Dockerfile for CUDA GPU packages |               |
 
 *Click on the image name in the table above for a current list of installed packages and versions*
 
@@ -32,6 +33,7 @@ graph TD;
     click pangeo-notebook "https://hub.docker.com/r/pangeo/pangeo-notebook" "Open this in a new tab" _blank
     click pytorch-notebook "https://hub.docker.com/r/pangeo/pytorch-notebook" "Open this in a new tab" _blank
     click ml-notebook "https://hub.docker.com/r/pangeo/ml-notebook" "Open this in a new tab" _blank
+    cuda-notebook;
 ```
 
 ### Using the image with Singularity on HPC systems
@@ -63,3 +65,4 @@ The primary use of these Docker images is running on Pangeo Cloud deployments wi
 * There used to be a `pangeo/forge` image, built for use with [pangeo-forge](https://pangeo-forge.org/). It is
   no longer actively maintained or used, but you can still use the [historical tags](https://quay.io/repository/pangeo/forge?tab=tags)
   if you wish.
+* In 2025.04, we've added a `cuda-notebook` image based on [`rapidsai/miniforge-cuda`](https://hub.docker.com/r/rapidsai/miniforge-cuda).

--- a/cuda-notebook/Dockerfile
+++ b/cuda-notebook/Dockerfile
@@ -1,0 +1,32 @@
+# Dockerfile for pangeo images with CUDA dependencies
+FROM rapidsai/miniforge-cuda:cuda12.8.0-base-ubuntu24.04-py3.13
+
+LABEL org.opencontainers.image.source=https://github.com/pangeo-data/pangeo-docker-images
+
+ENV CONDA_ENV=notebook\
+    NB_USER=jovyan\
+    NB_UID=1000 \
+    SHELL=/bin/bash \
+    CONDA_DIR=/opt/conda
+ENV NB_PYTHON_PREFIX=${CONDA_DIR}/envs/${CONDA_ENV}
+ENV PATH=${NB_PYTHON_PREFIX}/bin:${CONDA_DIR}/bin:${PATH}
+
+RUN echo "Creating ${NB_USER} user..." \
+    # Change user name from ubuntu to jovyan
+    && usermod --login ${NB_USER} ubuntu \
+    # Change group name from ubuntu to jovyan
+    && groupmod --new-name ${NB_USER} ubuntu \
+    # Set home directory of jovyan user
+    && usermod --home /home/${NB_USER} --move-home ${NB_USER} \
+    # Make sure that /opt/conda is owned by non-root user, so we can install things there
+    && chown -R ${NB_USER}:${NB_USER} ${CONDA_DIR}
+
+USER ${NB_USER}
+WORKDIR /home/${NB_USER}
+
+RUN mamba env create --name ${CONDA_ENV} --yes \
+    cuda-version=12.8 \
+    jupyterhub-singleuser=5
+
+EXPOSE 8888
+CMD ["jupyter", "lab", "--no-browser", "--ip", "0.0.0.0"]


### PR DESCRIPTION
Foundational Dockerfile for CUDA GPU packages, based off [rapidsai/miniforge-cuda](https://hub.docker.com/r/rapidsai/miniforge-cuda).

Chain of Docker images:

```mermaid
graph LR;
    ubuntu["ubuntu-24.04"]-->nvidia-cuda["nvidia/cuda<br>:12.8.0-base-ubuntu24.04"]
    nvidia-cuda-->rapidsai-miniforge["rapidsai/miniforge-cuda<br>:cuda12.8.0-base-ubuntu24.04-py3.13"]
    rapidsai-miniforge-->cuda-notebook["pangeo/cuda-notebook"]
    cuda-notebook-->cupy-notebook["pangeo/cupy-notebook (TODO)"]
   
   click nvidia-cuda "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda" "Open this in a new tab" _blank
    click rapidsai-miniforge "https://hub.docker.com/r/rapidsai/miniforge-cuda" "Open this in a new tab" _blank
```

Notes:
- Not using [`rapidsai/base` or `rapidsai/notebooks`](https://github.com/rapidsai/docker) because
  1. they contain **all** RAPIDS AI libraries, that add up to about 10GB+. We can depend on a minimal set that the Pangeo community needs (e.g. `cuspatial` and `kvikio`?).
  2. They use `/home/rapids` with UID 1001, so incompatible with repo2docker's `/home/jovyan` with UID 1000 setup. We do need to rename `/home/ubuntu` to `/home/jovyan` in the `rapidsai/miniforge-cuda` image though following [this](https://linuxconfig.org/changing-your-ubuntu-username-and-home-directory-without-losing-application-settings), xref https://github.com/jupyterhub/repo2docker/issues/1346

Packages in `cuda-notebook`:
- [x] cuda-version
- [x] jupyterhub-singleuser

Packages in `cupy-notebook`:
- [ ] cuspatial
- [ ] cupy-xarray
- [ ] etc

TODO:
- [x] Initial Dockerfile setup
- [ ] Bring over more of `base-image` docker tricks to `cuda-notebook`
- [ ] Create `cupy-notebook` using repo2docker style (i.e. dependencies in environment.yml
- [ ] etc

References:
- https://gitlab.com/nvidia/container-images/cuda
- https://github.com/rapidsai/ci-imgs
- https://github.com/rapidsai/docker

Resolves #457