### PR TITLE
Add Python Optimal Transport to the pangeo-notebook environment

### DIFF
--- a/pangeo-notebook/environment.yml
+++ b/pangeo-notebook/environment.yml
@@ -88,6 +88,7 @@ dependencies:
  #- parcels
  - param
  - planetary-computer
+ - pot
  - pop-tools
  - pyarrow
  - pycamhd


### PR DESCRIPTION
I'd like to add the [Python Optimal Transport (POT)](https://pythonot.github.io/) library to the pangeo-notebook environment on the leap-pangeo 2i2c hub. I'm using POT to calculate ND Wasserstein distances between large probability distributions generated from ocean gcm data, which is a very intensive but easily parallelizable calculation that I'd like to perform using Dask Gateway. I've discussed this with @weiji14 in [this issue](https://github.com/pangeo-data/pangeo-docker-images/issues/611) and they think it would be a reasonable package to add.

Thanks!
