### PR TITLE
Add libgdal-arrow-parquet driver

### DIFF
--- a/pangeo-notebook/environment.yml
+++ b/pangeo-notebook/environment.yml
@@ -65,6 +65,7 @@ dependencies:
  - jupyter-resource-usage
  - jupyter-sshd-proxy
  - kerchunk
+ - libgdal-arrow-parquet
  - line_profiler
  - lonboard
  - lxml


### PR DESCRIPTION
Adding the `libgdal-arrow-parquet` driver for GDAL/OGR to support reading Geoparquet files.

Requested at https://github.com/NASA-IMPACT/pangeo-notebook-veda-image/issues/36