### PR TITLE
Fix permissions for chatops actions to add reactions

### DIFF
--- a/.github/workflows/ChatOpsDispatcher.yml
+++ b/.github/workflows/ChatOpsDispatcher.yml
@@ -6,22 +6,20 @@ on:
     types: [created]
 
 permissions:
-  issues: write
+  contents: read
 
 jobs:
   slashCommandDispatch:
+    permissions:
+      pull-requests: write # for peter-evans/slash-command-dispatch to create PR reaction
+    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v4
+        uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4 # v4.0.0
         with:
-          token: ${{ secrets.PANGEOBOT_TOKEN }}
-          reaction-token: ${{ secrets.GITHUB_TOKEN }}
-          config: >
-            [
-              {
-                "command": "condalock",
-                "permission": "none",
-                "issue_type": "pull-request"
-              }
-            ]
+          token: ${{ github.token }}
+          commands: |
+            condalock
+          permission: none
+          issue-type: pull-request

--- a/.github/workflows/CondaLock.yml
+++ b/.github/workflows/CondaLock.yml
@@ -64,7 +64,8 @@ jobs:
     needs: condalock
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # for Git to git push
+      pull-requests: write # for peter-evans/create-or-update-comment to create PR reaction
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5
@@ -88,7 +89,7 @@ jobs:
           git push
 
       - name: Add reaction
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}


### PR DESCRIPTION
Was getting `Warning: Failed to set reaction on comment ID XXX` and `Adding reaction 'hooray' to comment id 'XXX' failed` due to missing write permissions to pull-requests. Noticed this at https://github.com/pangeo-data/pangeo-docker-images/pull/602#issuecomment-3330258265, where earlier comments had emoji reactions, but latter ones didn't.

Changes to set `permissions: pull-requests: write` where needed, and also changed from using `PANGEOBOT_TOKEN` to the default `GITHUB_TOKEN` in one instance.

References:
- https://github.com/CryoInTheCloud/hub-image/blame/cd4cd01e83c3d512d3d8947c6af56dd316a8c6c0/.github/workflows/slash-command-dispatch.yml#L14-L16
- https://github.com/peter-evans/slash-command-dispatch/issues/376
- https://github.com/peter-evans/slash-command-dispatch/issues/147#issuecomment-1489438442