### PR TITLE
Set permissions to contents: write to exec repository_dispatch event

### DIFF
--- a/.github/workflows/ChatOpsDispatcher.yml
+++ b/.github/workflows/ChatOpsDispatcher.yml
@@ -5,12 +5,12 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   slashCommandDispatch:
     permissions:
+      contents: write # for executing the repository_dispatch event
       pull-requests: write # for peter-evans/slash-command-dispatch to create PR reaction
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes `Error: Resource not accessible by integration` mentioned at https://github.com/pangeo-data/pangeo-docker-images/pull/625/files#r2377352047

References:
- https://github.com/peter-evans/slash-command-dispatch/issues/147#issuecomment-1489438442
- https://github.com/peter-evans/repository-dispatch/issues/196#issuecomment-1504067029