### PR TITLE
Secure some GH Actions and use ubuntu-slim for some workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "quarterly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/BinderPR.yml
+++ b/.github/workflows/BinderPR.yml
@@ -9,7 +9,7 @@ jobs:
   trigger-chatops:
     # Make sure the comment is on a PR, and contains the command "/binder"
     if: (github.event.issue.pull_request != null) && contains(github.event.comment.body, '/binder')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: write
 

--- a/.github/workflows/ChatOpsDispatcher.yml
+++ b/.github/workflows/ChatOpsDispatcher.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write # for executing the repository_dispatch event
       pull-requests: write # for peter-evans/slash-command-dispatch to create PR reaction
     if: ${{ github.event.issue.pull_request }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5.0.2

--- a/.github/workflows/CondaLock.yml
+++ b/.github/workflows/CondaLock.yml
@@ -62,7 +62,7 @@ jobs:
   # Each job will commit files, so we know it succeeds based on commits
   commit-lockfiles:
     needs: condalock
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write # for Git to git push
       pull-requests: write # for peter-evans/create-or-update-comment to create PR reaction

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   DeployPangeoBot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'pangeo-data/pangeo-docker-images'
 
     steps:

--- a/.github/workflows/WatchCondaForge.yml
+++ b/.github/workflows/WatchCondaForge.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get Latest pangeo-notebook Metapackage Version
         id: latest_version
-        uses: jacobtomlinson/gha-anaconda-package-version@0.1.4
+        uses: jacobtomlinson/gha-anaconda-package-version@f5d2c85fa7353b97ce642c233499724caa82328d # 0.1.4
         with:
           org: "conda-forge"
           package: "pangeo-notebook"
@@ -30,7 +30,7 @@ jobs:
 
       - name: Find and Replace pangeo-notebook
         id: find_replace
-        uses: jacobtomlinson/gha-find-replace@3.0.5
+        uses: jacobtomlinson/gha-find-replace@f1069b438f125e5395d84d1c6fd3b559a7880cb5 # 3.0.5
         with:
           include: "base-notebook/environment.yml"
           find: "pangeo-notebook=.*"
@@ -61,7 +61,7 @@ jobs:
       - name: Create Pull Request
         if: steps.check_branch.outputs.exists == 'False' && steps.find_replace.outputs.modifiedFiles > 0
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           committer: Pangeo Bot <pangeo-bot@users.noreply.github.com>
           token: ${{ secrets.PANGEOBOT_TOKEN }}

--- a/.github/workflows/WatchCondaForge.yml
+++ b/.github/workflows/WatchCondaForge.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   check-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'pangeo-data/pangeo-docker-images'
 
     steps:

--- a/.github/workflows/WatchCondaForge.yml
+++ b/.github/workflows/WatchCondaForge.yml
@@ -39,16 +39,18 @@ jobs:
       - name: Set Environment Variables
         run: |
           CALVER="$( date -u '+%Y.%m.%d' )"
-          PR_BRANCH="upgrade-pangeo-metapackage-${{ steps.latest_version.outputs.version }}"
+          PR_BRANCH="upgrade-pangeo-metapackage-${STEPS_LATEST_VERSION_OUTPUTS_VERSION}"
           echo "CALVER=${CALVER}" >> $GITHUB_ENV
           echo "PR_BRANCH=${PR_BRANCH}" >> $GITHUB_ENV
+        env:
+          STEPS_LATEST_VERSION_OUTPUTS_VERSION: ${{ steps.latest_version.outputs.version }}
 
       - name: Check if PR Already Exists
         id: check_branch
         run: |
           # https://github.com/actions/checkout#fetch-all-branches
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-          if git show-ref --quiet refs/remotes/origin/${{env.PR_BRANCH}}; then
+          if git show-ref --quiet refs/remotes/origin/${PR_BRANCH}; then
             RESULT=True
           else
             RESULT=False


### PR DESCRIPTION
Gradually securing our GitHub Actions workflows a bit, tackling some low-hanging fruit for now identified by [Zizmor](https://docs.zizmor.sh/audits):

- [x] https://docs.zizmor.sh/audits/#dependabot-cooldown
- [x] https://docs.zizmor.sh/audits/#template-injection
- [x] https://docs.zizmor.sh/audits/#unpinned-uses
- [ ] there are more, but will tackle them in the future as they are more involved

Also switching from `ubuntu-latest` to `ubuntu-slim` for some lightweight workflows (https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/) to save a bit of energy.

Note: I've also changed some settings at https://github.com/pangeo-data/pangeo-docker-images/settings/actions to tighthen up the permissions, so it'll be harder for breaches in general.