### PR TITLE
Don't build linux-aarch64 (linux/arm64) ML images

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -72,7 +72,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        IMAGE: [base-notebook, pangeo-notebook, ml-notebook, pytorch-notebook]
+        include:
+          - IMAGE: base-notebook
+            platforms: linux/arm64
+          - IMAGE: pangeo-notebook
+            platforms: linux/arm64
+          - IMAGE: ml-notebook
+            platforms: linux/amd64,linux/arm64
+          - IMAGE: pytorch-notebook
+            platforms: linux/amd64,linux/arm64
     name: ${{ matrix.IMAGE }}
     runs-on: ubuntu-latest
     steps:
@@ -120,7 +128,7 @@ jobs:
       with:
         context: ${{ matrix.IMAGE }}
         push: true
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ matrix.platforms }}
         tags: |
           ${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}:master
           ${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}:${{env.DOCKER_TAG}}

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -74,9 +74,9 @@ jobs:
       matrix:
         include:
           - IMAGE: base-notebook
-            platforms: linux/arm64,linux/arm64
+            platforms: linux/amd64,linux/arm64
           - IMAGE: pangeo-notebook
-            platforms: linux/arm64,linux/arm64
+            platforms: linux/amd64,linux/arm64
           - IMAGE: ml-notebook
             platforms: linux/amd64
           - IMAGE: pytorch-notebook

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -74,13 +74,13 @@ jobs:
       matrix:
         include:
           - IMAGE: base-notebook
-            platforms: linux/arm64
+            platforms: linux/arm64,linux/arm64
           - IMAGE: pangeo-notebook
-            platforms: linux/arm64
+            platforms: linux/arm64,linux/arm64
           - IMAGE: ml-notebook
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - IMAGE: pytorch-notebook
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
     name: ${{ matrix.IMAGE }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -66,7 +66,7 @@ jobs:
       uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         context: base-image
-        platforms:
+        platforms: ${{ matrix.platforms }}
         tags: localhost:5000/pangeo/base-image:PR
         push: true
         cache-from: type=gha

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -23,9 +23,9 @@ jobs:
       matrix:
         include:
           - IMAGE: base-notebook
-            platforms: linux/arm64,linux/arm64
+            platforms: linux/amd64,linux/arm64
           - IMAGE: pangeo-notebook
-            platforms: linux/arm64,linux/arm64
+            platforms: linux/amd64,linux/arm64
           - IMAGE: ml-notebook
             platforms: linux/amd64
           - IMAGE: pytorch-notebook

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -21,7 +21,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        IMAGE: [base-notebook, pangeo-notebook, ml-notebook, pytorch-notebook]
+        include:
+          - IMAGE: base-notebook
+            platforms: linux/arm64,linux/arm64
+          - IMAGE: pangeo-notebook
+            platforms: linux/arm64,linux/arm64
+          - IMAGE: ml-notebook
+            platforms: linux/amd64
+          - IMAGE: pytorch-notebook
+            platforms: linux/amd64
     name: ${{ matrix.IMAGE }}
     runs-on: ubuntu-latest
     services:
@@ -58,7 +66,7 @@ jobs:
       uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         context: base-image
-        platforms: linux/amd64,linux/arm64
+        platforms:
         tags: localhost:5000/pangeo/base-image:PR
         push: true
         cache-from: type=gha
@@ -68,7 +76,7 @@ jobs:
       uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         context: ${{ matrix.IMAGE }}
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ matrix.platforms }}
         push: true
         tags: localhost:5000/${{env.DOCKER_ORG}}/${{ matrix.IMAGE }}:PR
         build-args: PANGEO_BASE_IMAGE_TAG=PR

--- a/environment-condalock.yml
+++ b/environment-condalock.yml
@@ -1,4 +1,4 @@
-name: condalock2
+name: condalock
 channels:
   - conda-forge
 dependencies:

--- a/environment-condalock.yml
+++ b/environment-condalock.yml
@@ -1,8 +1,8 @@
-name: condalock
+name: condalock2
 channels:
   - conda-forge
 dependencies:
-  - python=3.12
-  - conda-lock>=2.5
-  - conda>=24.5.0
-  - mamba=1
+  - python=3.14
+  - conda-lock>=4
+  - conda=26
+  - mamba=2


### PR DESCRIPTION
- Partially addresses #653 to simply skip linux/arm64 builds for pytorch and ml environments
- Alternative if the conda packages all now work with linux-aarch64 somebody can follow up to add that! 
- Also updates the conda-lock environment since it's been a while