### PR TITLE
Solve for linux-aarch64 platform for pytorch-notebook and ml-notebook

### DIFF
--- a/.github/workflows/CondaLock.yml
+++ b/.github/workflows/CondaLock.yml
@@ -46,8 +46,8 @@ jobs:
           elif [ ${{ matrix.IMAGE }} = "pangeo-notebook" ]; then
             conda-lock lock -f environment.yml -f ../base-notebook/environment.yml -p linux-64 -p linux-aarch64 -p osx-64 -p osx-arm64
           else
-            # Linux-64 ONLY
-            conda-lock lock -f environment.yml -f ../pangeo-notebook/environment.yml -f ../base-notebook/environment.yml -p linux-64
+            # linux-64 and linux-aarch64 ONLY
+            conda-lock lock -f environment.yml -f ../pangeo-notebook/environment.yml -f ../base-notebook/environment.yml -p linux-64 -p linux-aarch64
           fi
           # Keep this format around for easy `conda install` w/o conda-lock or micromamba
           conda-lock render -k explicit -p linux-64


### PR DESCRIPTION
Build `pytorch-notebook` and `ml-notebook` under linux-aarch64 platform, in addition to existing linux-64 platform build.

Addresses https://github.com/pangeo-data/pangeo-docker-images/issues/396#issuecomment-2197784077