### PR TITLE
Reverse order of environment.yml files in ml-notebook & pin to python312

### DIFF
--- a/.github/workflows/CondaLock.yml
+++ b/.github/workflows/CondaLock.yml
@@ -50,7 +50,7 @@ jobs:
             conda-lock lock -f environment.yml -f ../pangeo-notebook/environment.yml -f ../base-notebook/environment.yml -p linux-64 -p linux-aarch64
           else
             # linux-64 ONLY
-            conda-lock lock -f environment.yml -f ../pangeo-notebook/environment.yml -f ../base-notebook/environment.yml -p linux-64
+            conda-lock lock -f ../base-notebook/environment.yml -f ../pangeo-notebook/environment.yml -f environment.yml -p linux-64
           fi
           # Keep this format around for easy `conda install` w/o conda-lock or micromamba
           conda-lock render -k explicit -p linux-64

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ pangeo-notebook : base-image
 .PHONY: ml-notebook
 ml-notebook : base-image
 	cd ml-notebook ; \
-	conda-lock lock -f environment.yml -f ../pangeo-notebook/environment.yml -f ../base-notebook/environment.yml -p linux-64; \
+	conda-lock lock -f ../base-notebook/environment.yml -f ../pangeo-notebook/environment.yml -f environment.yml -p linux-64; \
 	conda-lock render -k explicit -p linux-64; \
 	../generate-packages-list.py conda-linux-64.lock > packages.txt; \
 	docker build -t pangeo/ml-notebook:master . ; \

--- a/base-notebook/conda-linux-64.lock
+++ b/base-notebook/conda-linux-64.lock
@@ -95,7 +95,7 @@ https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda#554
 https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda#61b8078a0905b12529abc622406cb62c
 https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda#2da13f2b299d8e1995bafbbe9689a2f7
 https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda#f54c1ffb8ecedb85a8b7fcde3a187212
-https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda#ee1b48795ceb07311dd3e665dd4f5f33
+https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py312h8285ef7_0.conda#e6778419a1851f6e15820558abddfa04
 https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda#61dcf784d59ef0bd62c57d982b154ace
 https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2#961b3a227b437d82ad7054484cfa71b2
 https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda#ff9efb7f7469aed3c4a8106ffa29593c
@@ -152,7 +152,7 @@ https://conda.anaconda.org/conda-forge/noarch/tblib-3.2.2-pyhcf101f3_0.conda#f88
 https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda#b5325cf06a000c5b14970462ff5e4d58
 https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda#c07a6153f8306e45794774cf9b13bd32
 https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.6-py312h4c3975b_0.conda#dcbe46475eff6fb9d1adad473c984f39
-https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda#4bada6a6d908a27262af8ebddf4f7492
+https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda#37e3be7b6e2977d37b8fa5da229f5dc0
 https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda#0caa1af407ecff61170c9437a808404d
 https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda#f6d7aa696c67756a650e91e15e88223c
 https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda#e7cb0f5745e4c5035a460248334af7eb

--- a/base-notebook/conda-lock.yml
+++ b/base-notebook/conda-lock.yml
@@ -3584,7 +3584,7 @@ package:
   category: main
   optional: false
 - name: debugpy
-  version: 1.8.20
+  version: 1.8.21
   manager: conda
   platform: linux-64
   dependencies:
@@ -3593,14 +3593,14 @@ package:
     libstdcxx: '>=14'
     python: ''
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py312h8285ef7_0.conda
   hash:
-    md5: ee1b48795ceb07311dd3e665dd4f5f33
-    sha256: f20121b67149ff80bf951ccae7442756586d8789204cd08ade59397b22bfd098
+    md5: e6778419a1851f6e15820558abddfa04
+    sha256: b8dbe25820064a099f315bbb8f45f5bac3fddb63e96af3cbf0c93a830733ef34
   category: main
   optional: false
 - name: debugpy
-  version: 1.8.20
+  version: 1.8.21
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -3608,29 +3608,29 @@ package:
     libstdcxx: '>=14'
     python: 3.12.*
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/debugpy-1.8.20-py312hf55c4e8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/debugpy-1.8.21-py312hf55c4e8_0.conda
   hash:
-    md5: d7ee86593223e812e41612678c26a10d
-    sha256: c041ed2da3fd1e237972a360cb0f532a0caf66f571fdc9ec2cc07ccb48b8c665
+    md5: 228761e2c5f069dc8445337bd4abe097
+    sha256: 9d8a3442fae659629980c972b5f7ba8c2d339d233bd1de38ae72faf244cdc3a9
   category: main
   optional: false
 - name: debugpy
-  version: 1.8.20
+  version: 1.8.21
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
     python: ''
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.20-py312h29de90a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.21-py312h4075484_0.conda
   hash:
-    md5: 4e508cd9d5d630c7db0bdebb24a3be90
-    sha256: 310f737be38bd4a53b2c13c6387b880031fc0995a13194511cc08a48d3160462
+    md5: bd3377921dea4d723151ace2334ee481
+    sha256: e512cf9a11116a05f43a40c1a2a57f094945a80b514c77638c770897be3f4308
   category: main
   optional: false
 - name: debugpy
-  version: 1.8.20
+  version: 1.8.21
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3638,10 +3638,10 @@ package:
     libcxx: '>=19'
     python: 3.12.*
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.20-py312h6510ced_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.21-py312h6510ced_0.conda
   hash:
-    md5: da3b5efcb0caabcede61a6ce4e0a7669
-    sha256: f0ca130b5ffd6949673d3c61d7b8562ab76ad8debafb83f8b3443d30c172f5eb
+    md5: 178381b74c5e84ea90751c5e4291c41e
+    sha256: 80589b2da39c84c0786f13a0a4c98cde9a879207af0482bd1f9b29d2f6fe277b
   category: main
   optional: false
 - name: decorator
@@ -7646,27 +7646,27 @@ package:
   category: main
   optional: false
 - name: libcxx
-  version: 22.1.6
+  version: 22.1.7
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.6-h19cb2f5_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.7-h19cb2f5_0.conda
   hash:
-    md5: fa1bbb55bfda7a8a022d508fb03f1625
-    sha256: 6d60efb63fe4d0299526fcb26e06de1933de55c36fc2ae5a1478f1aa734604bb
+    md5: 423373b842c3861da6cfa8c8915798ce
+    sha256: c03c298355dea54b729ed6c5f1e6dbd0e2426906039eba8aa2ba1254d005b7d8
   category: main
   optional: false
 - name: libcxx
-  version: 22.1.6
+  version: 22.1.7
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.6-h55c6f16_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.7-h55c6f16_0.conda
   hash:
-    md5: 589cc6f6222fdc0eaf8e90bc38fcce7b
-    sha256: 3e2f8ad32ddab88c5114b9aa2160f8c129f515df0e551d0d86ef5744446afdbd
+    md5: 0325fbe13eb6dd39234eb305ac1b3cb8
+    sha256: cceb668dc1b71f054b1036dd83eca2e02c0c3a4b2ba3ad28c74a982d819597a3
   category: main
   optional: false
 - name: libdeflate
@@ -9948,27 +9948,27 @@ package:
   category: main
   optional: false
 - name: llvm-openmp
-  version: 22.1.6
+  version: 22.1.7
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.6-h0d3cbff_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.7-h0d3cbff_0.conda
   hash:
-    md5: b67316dec3b5c028b6b1bb6fd713c14e
-    sha256: afbea63c0ffed8f150ba41a3e85bd849560f15f879d0f1b5e5fb6b90eca8ea78
+    md5: 301c1db2d75ac8a91f46d21652e08dd6
+    sha256: c8eeb6bca45680db8974b78e0524b2ab3c285a9916a0b3356329d1f949b1311b
   category: main
   optional: false
 - name: llvm-openmp
-  version: 22.1.6
+  version: 22.1.7
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.6-hc7d1edf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.7-hc7d1edf_0.conda
   hash:
-    md5: b8cf70b77b2ed10d5f82e367c327b76b
-    sha256: 12d3652549a9abd30f3cc14797715327b86e91001d11865106eb3e02c40be9da
+    md5: 7c6a5897a8bc5b6d509a4ee9dec7fcc8
+    sha256: 6bf27376f11198c01a88a1c8234470f45bce0aa7502b7e7988ef03ef5db3a890
   category: main
   optional: false
 - name: locket
@@ -14992,51 +14992,51 @@ package:
   category: main
   optional: false
 - name: traitlets
-  version: 5.15.0
+  version: 5.15.1
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
-    md5: 4bada6a6d908a27262af8ebddf4f7492
-    sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
+    md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+    sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
   category: main
   optional: false
 - name: traitlets
-  version: 5.15.0
+  version: 5.15.1
   manager: conda
   platform: linux-aarch64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
-    md5: 4bada6a6d908a27262af8ebddf4f7492
-    sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
+    md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+    sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
   category: main
   optional: false
 - name: traitlets
-  version: 5.15.0
+  version: 5.15.1
   manager: conda
   platform: osx-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
-    md5: 4bada6a6d908a27262af8ebddf4f7492
-    sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
+    md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+    sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
   category: main
   optional: false
 - name: traitlets
-  version: 5.15.0
+  version: 5.15.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
-    md5: 4bada6a6d908a27262af8ebddf4f7492
-    sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
+    md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+    sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
   category: main
   optional: false
 - name: typing-extensions

--- a/base-notebook/packages.txt
+++ b/base-notebook/packages.txt
@@ -60,7 +60,7 @@ dask==2026.1.1
 dask-core==2026.1.1
 dask-gateway==2025.4.0
 dask-labextension==7.0.0
-debugpy==1.8.20
+debugpy==1.8.21
 decorator==5.3.1
 defusedxml==0.7.1
 distributed==2026.1.1
@@ -258,7 +258,7 @@ tk==8.6.13
 tomli==2.4.1
 toolz==1.1.0
 tornado==6.5.6
-traitlets==5.15.0
+traitlets==5.15.1
 typing-extensions==4.15.0
 typing-inspection==0.4.2
 typing_extensions==4.15.0

--- a/ml-notebook/conda-linux-64.lock
+++ b/ml-notebook/conda-linux-64.lock
@@ -11,7 +11,6 @@ https://conda.anaconda.org/conda-forge/linux-64/gh-2.93.0-hfc2019e_0.conda#c4573
 https://conda.anaconda.org/conda-forge/linux-64/git-lfs-3.7.1-ha8f183a_1.conda#185f332b1a60ed24701358bb3c21aee2
 https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda#129e404c5b001f3ef5581316971e3ea0
 https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_0.conda#f8dcb0cff8f84f428bf76f1169bf50a7
-https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-mpich.conda#1052de900d672ec8b3713b8e300a8f06
 https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda#16c2a0e9c4a166e53632cfca4f68d020
 https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda#f0599959a2447c1e544e216bddf393fa
 https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda#c3efd25ac4d74b1584d2f7a57195ddf1
@@ -39,7 +38,7 @@ https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda#c2a0
 https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda#4a13eeac0b5c8e5b8ab496e6c4ddd829
 https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda#18335a698559cdbcd86150a48bf54ba6
 https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda#57736f29cc2b0ec0b6c2952d3f101b6a
-https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda#dcdc58c15961dbf17a0621312b01f5cb
+https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda#18d273b22e96c97c2017813f099faa82
 https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda#e36ad70a7e0b48f091ed6902f04c23b8
 https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda#d2ffd7602c02f2b316fd921d39876885
 https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda#920bb03579f15389b9e512095ad995b7
@@ -58,7 +57,6 @@ https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.
 https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda#915f5995e94f60e9a4826e0b0920ee88
 https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda#6178c6f2fb254558238ef4e6c56fb782
 https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda#b88d90cad08e6bc8ad540cb310a761fb
-https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda#db63358239cbe1ff86242406d440e44a
 https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda#d864d34357c3b65a4b731f78c0801dc4
 https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda#68e52064ed3897463c0e958ab5c8f91b
 https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda#2446ac1fe030c2aa6141386c1f5a6aed
@@ -100,7 +98,7 @@ https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda#f7d7
 https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda#4d4efd0645cd556fab54617c4ad477ef
 https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda#d411fc29e338efb48c5fd4576d71d881
 https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda#3bf7b9fd5a7136126e0234db4b87c8b6
-https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda#2cd94587f3a401ae05e03a6caf09539d
+https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda#cf09e9fc938518e91d0706572cadf17a
 https://conda.anaconda.org/conda-forge/linux-64/h3-4.4.1-h54a6638_0.conda#b8e023a9674dca4c703b5fa6218d22b8
 https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda#c80d8a3b84358cb967fa81e7075fbc8a
 https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda#10909406c1b0e4b57f9f4f0eb0999af8
@@ -197,7 +195,6 @@ https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.4-hb03c661_1.conda#c
 https://conda.anaconda.org/conda-forge/linux-64/onednn-cpu-threadpool-3.12-threadpool_hc2f90bd_0.conda#195c5b9d47c485a21085597d753bf55a
 https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda#7eccb41177e15cc672e1babe9056018e
 https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda#353823361b1d27eb3960efb076dfcaf6
-https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.0-h192683f_1.conda#da47d3251c0f0d16b2801afe5a77b532
 https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.17.0-hab81395_1.conda#a3b0e874fa56f72bc54e5c595712a333
 https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.1-hbc0de68_0.conda#8e0b8654ead18e50af552e54b5a08a61
 https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda#d71d3a66528853c0a1ac2c02d79a0284
@@ -238,7 +235,7 @@ https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda#2da1
 https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda#f54c1ffb8ecedb85a8b7fcde3a187212
 https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda#4c2a8fef270f6c69591889b93f9f55c1
 https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda#ce96f2f470d39bd96ce03945af92e280
-https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda#ee1b48795ceb07311dd3e665dd4f5f33
+https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py312h8285ef7_0.conda#e6778419a1851f6e15820558abddfa04
 https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda#61dcf784d59ef0bd62c57d982b154ace
 https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2#961b3a227b437d82ad7054484cfa71b2
 https://conda.anaconda.org/conda-forge/noarch/dill-0.4.1-pyhcf101f3_0.conda#080a808fce955026bf82107d955d32da
@@ -252,7 +249,7 @@ https://conda.anaconda.org/conda-forge/linux-64/fastar-0.11.0-py312h42cbcb6_0.co
 https://conda.anaconda.org/conda-forge/noarch/fastcore-1.13.2-pyhcf101f3_0.conda#84fc5b6dc5de080478b3dd30c212ad6a
 https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda#8fa8358d022a3a9bd101384a808044c6
 https://conda.anaconda.org/conda-forge/noarch/findlibs-0.1.2-pyhd8ed1ab_0.conda#fa9e9ec7bf26619a8edd3e11155f15d6
-https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.0-h27c8c51_0.conda#06965b2f9854d0b15e0443ee81fe83dc
+https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda#e0e050cfa9fa85fe39632ab11cb7f3e0
 https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda#8462b5322567212beeb025f3519fb3e2
 https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.8.0-py312h447239a_0.conda#6a42923f35087cc88a9fac31ef096ce6
 https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda#2c11aa96ea85ced419de710c1c3a78ff
@@ -261,7 +258,7 @@ https://conda.anaconda.org/conda-forge/noarch/gast-0.7.0-pyhd8ed1ab_0.conda#377a
 https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda#7892f39a39ed39591a89a28eba03e987
 https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.1-pyhd8ed1ab_0.conda#43dd16b113cc7b244d923b630026ff4f
 https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.1-hee1de02_2.conda#e5a459d2bb98edb88de5a44bfad66b9d
-https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-570.0.0-py312h7900ff3_0.conda#c4663cdd2a4653c0a84f95a0227c9b8d
+https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-571.0.0-py312h7900ff3_0.conda#dedf2ef75d0f01c92e73df4bfccb0a3c
 https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py312h03f33d3_1.conda#68f704ea294dcec9e09edd9c3d233846
 https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.1-py312h8285ef7_0.conda#3a704672326e552b019390d832a4b095
 https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda#4d8df0b0db060d33c9a702ada998a8fe
@@ -291,7 +288,6 @@ https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda#4
 https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda#c3cc2864f82a944bc90a7beb4d3b0e88
 https://conda.anaconda.org/conda-forge/linux-64/libcusolver-11.7.5.82-h676940d_2.conda#bb6e31a0daa64ede76fe8d3fff01c06f
 https://conda.anaconda.org/conda-forge/linux-64/libcusparse-dev-12.5.10.65-hecca717_2.conda#db94469fbd554c107acc3afd0af5d8ec
-https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.1-h6b3ec72_1.conda#4a7168d686b6125ba546134dddb16721
 https://conda.anaconda.org/conda-forge/linux-64/libfido2-1.17.0-h8c08ba8_0.conda#f3a2fbd4644599669d5f274f98c04b30
 https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda#ec3c4350aa0261bf7f87b8ca15c8e80e
 https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-haa4a5bd_1023.conda#953b7cca897e21215302dbfe2af5cd0c
@@ -379,12 +375,11 @@ https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda#b53
 https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda#c07a6153f8306e45794774cf9b13bd32
 https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.6-py312h4c3975b_0.conda#dcbe46475eff6fb9d1adad473c984f39
 https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda#e5ce43272193b38c2e9037446c1d9206
-https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda#4bada6a6d908a27262af8ebddf4f7492
-https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.0-pyhd8ed1ab_0.conda#c9e0f517471f71f4a5ebac45ae3bbfa2
+https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda#37e3be7b6e2977d37b8fa5da229f5dc0
+https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.1-pyhd8ed1ab_0.conda#f811b6bf76aba2311c448d5cedaaf080
 https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda#0caa1af407ecff61170c9437a808404d
 https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda#f6d7aa696c67756a650e91e15e88223c
 https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-2.0.0-pyhcf101f3_0.conda#4fdd327852ffefc83173a7c029690d0c
-https://conda.anaconda.org/conda-forge/linux-64/ucx-1.20.1-hbe80e26_0.conda#7d06bc10996e75c90b8cd7631b5dcf6c
 https://conda.anaconda.org/conda-forge/linux-64/ujson-5.12.1-py312h8285ef7_1.conda#1a16c1e03a6d960a183086adabd4a52a
 https://conda.anaconda.org/conda-forge/noarch/uncompresspy-0.4.1-pyhd8ed1ab_0.conda#06de15bda7ff6019d8e02e6682664b63
 https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda#0b6c506ec1f272b685240e70a29261b8
@@ -456,7 +451,6 @@ https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.7-gpl_hc2c16d8_10
 https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda#33a413f1095f8325e5c30fde3b0d2445
 https://conda.anaconda.org/conda-forge/linux-64/libcudnn-dev-9.10.2.21-h58dd1b1_0.conda#7d7a47d067261531c3089dcec326d6fa
 https://conda.anaconda.org/conda-forge/linux-64/libcusolver-dev-11.7.5.82-h676940d_2.conda#0fe12e558abf507458bcec839e29778d
-https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.1-ha770c72_1.conda#0b82ff1ab3db9122f20cafe93f61bc3b
 https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h5fbf134_12.conda#88c1c66987cd52a712eea89c27104be6
 https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda#f25206d7322c0e9648e8b83694d143ab
 https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda#16b6330783ce0d1ae8d22782173b32c9
@@ -550,7 +544,7 @@ https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda#d354
 https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-h215f996_4.conda#b39dccf5af984bcb68ee2aa0f3213ea6
 https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.50-pyhd8ed1ab_0.conda#98958318a01373a615f119b1040b3027
 https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.78.1-py312h39ee1c6_0.conda#b1995dadc14463d8f914c54cf2061a07
-https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda#e194f6a2f498f0c7b1e6498bd0b12645
+https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda#21ee4640b7c2d94e584349fa12b29b9a
 https://conda.anaconda.org/conda-forge/noarch/importlib-resources-7.1.0-pyhd8ed1ab_0.conda#e3bffa82b874f8b9a2631bddb3869529
 https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.0-pyh53cf698_0.conda#8e3caf9b45475eb00053f4bb60be0d15
 https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda#439cd0f567d697b20a8f45cb70a1005a
@@ -565,7 +559,6 @@ https://conda.anaconda.org/conda-forge/linux-64/lxml-6.1.1-py312h63ddcf0_0.conda
 https://conda.anaconda.org/conda-forge/noarch/mako-1.3.12-pyhcf101f3_0.conda#a73036dabdd6dfe9679ed893baa8b230
 https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.2-pyhcf101f3_0.conda#ba0a9221ce1063f31692c07370d062f3
 https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda#ad6821df7a98510117db06e9a833281f
-https://conda.anaconda.org/conda-forge/linux-64/mpich-5.0.1-h6f9170e_0.conda#47a868b6ab372a8623f2a612d5979940
 https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.6-py312h33ff503_0.conda#6e31d55ee1110fda83b4f4045f4d73ff
 https://conda.anaconda.org/conda-forge/noarch/obspec_utils-0.9.0-pyhd8ed1ab_0.conda#3289f38214d30fa6f32540d3fcb7c278
 https://conda.anaconda.org/conda-forge/linux-64/optree-0.19.1-py312hd9148b4_0.conda#5a9273e06750ca36e478c142813e59a8
@@ -608,7 +601,7 @@ https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-grpc-1.75
 https://conda.anaconda.org/conda-forge/noarch/grpcio-status-1.78.1-pyhcf101f3_0.conda#829271a8ea9d8024e99e43939ebb114f
 https://conda.anaconda.org/conda-forge/linux-64/gsw-3.6.21-py312h5253ce2_0.conda#6854d74d7179915efa7f044b9fe0d39b
 https://conda.anaconda.org/conda-forge/linux-64/h3-py-4.4.1-py312h372c3de_0.conda#32bfdf13d18d0ce46bbfda987d61393f
-https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-mpi_mpich_h1a5cfed_5.conda#847f1a715e324125f8e67cffeb9a7887
+https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda#0d0595612fa229dddb5fc565c260a11f
 https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda#4f14640d58e2cc0aa0819d9d8ba125bb
 https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2026.5.10-py312h7d53d09_1.conda#30450910826efe1f291ce643a283a52c
 https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda#b5577bc2212219566578fd5af9993af6
@@ -625,7 +618,6 @@ https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.3-he63569f_3.c
 https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda#8ae0593085ca8148fdbf0bc8f62e79c1
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2026.1.0-hb56ce9e_4.conda#bf0b7cde9e67d746db3dac68b563de77
 https://conda.anaconda.org/conda-forge/linux-64/libplacebo-7.360.1-h9eeb4b2_0.conda#e6324dfe6c02e0736bb9235f8ef3c8a6
-https://conda.anaconda.org/conda-forge/linux-64/libpnetcdf-1.14.1-mpi_mpich_h0009a5c_101.conda#2ec7034ce2c75d98ba3f73af3fecff08
 https://conda.anaconda.org/conda-forge/linux-64/libtensorflow_framework-2.19.1-cuda128hc512d3a_255.conda#321e3c430474f9b9e2d1f9d96afbf5cd
 https://conda.anaconda.org/conda-forge/noarch/lsprotocol-2025.0.0-pyhe01879c_0.conda#f0680112562ae328ef9ce60545879cf9
 https://conda.anaconda.org/conda-forge/linux-64/ml_dtypes-0.5.4-np2py312h0f77346_1.conda#657a00c06d327012fb3002e5600b2976
@@ -655,7 +647,7 @@ https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda#9a
 https://conda.anaconda.org/conda-forge/noarch/starlette-1.2.1-pyhcf101f3_0.conda#42f2b5375c39905cf8b020bbd85f687b
 https://conda.anaconda.org/conda-forge/noarch/tensorboard-2.19.0-pyhd8ed1ab_0.conda#59cc119240f48dc05369fa8bea07ea05
 https://conda.anaconda.org/conda-forge/noarch/treescope-0.1.10-pyhcf101f3_0.conda#1ffcc20967a4e3bbea41ab3ba1af663f
-https://conda.anaconda.org/conda-forge/noarch/typer-0.26.5-pyhcf101f3_0.conda#af2517b95781c326d315514ff1460453
+https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda#71d2c80673511fab927bd15592994030
 https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.2.0-py312h0ccc70a_0.conda#331d2437900a5e2d54641308d3445236
 https://conda.anaconda.org/conda-forge/noarch/watermark-2.6.0-pyhcf101f3_0.conda#05030c85ab3ec75ed1f9eb2b7fd62a74
 https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda#39f70aca52f1497a72eb9d81baf4d237
@@ -663,7 +655,7 @@ https://conda.anaconda.org/conda-forge/noarch/anywidget-0.11.0-pyhd8ed1ab_0.cond
 https://conda.anaconda.org/conda-forge/linux-64/astropy-base-7.2.0-py312h4f23490_0.conda#a2826f4e9101450669fcfbe1b3b16820
 https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2#6b889f174df1e0f816276ae69281af4d
 https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.747-h41c0014_4.conda#169a79ea1127077d8dc36dc963ff55ac
-https://conda.anaconda.org/conda-forge/linux-64/awscli-2.34.58-py312h20c3967_0.conda#9c785409a34374d635bbdaf44345ed83
+https://conda.anaconda.org/conda-forge/linux-64/awscli-2.34.60-py312h20c3967_0.conda#b6573c0ff4ef231402878f918d28f41e
 https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.15.0-h1e5b466_0.conda#c9186aa979528963657db3e63c25e987
 https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.0-pyhd8ed1ab_0.conda#b9a6da57e94cd12bd71e7ab0713ef052
 https://conda.anaconda.org/conda-forge/noarch/bqscales-0.3.7-pyhd8ed1ab_1.conda#5325324a656c5490644fc3961e681ab6
@@ -691,7 +683,7 @@ https://conda.anaconda.org/conda-forge/noarch/kagglesdk-0.1.27-pyhcf101f3_0.cond
 https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.3-hf70aa56_3.conda#5429ab06028218ac67e11695b4b66a96
 https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.3-ha9bf034_3.conda#f019b2a48a736bf0357b0e24176ab941
 https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda#6f79d5f72cfcdd3509112233a8aedc2e
-https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-mpi_mpich_h65e3e28_4.conda#5954d774093fd57ba35ad04265c22a9e
+https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_h3c9b436_104.conda#6d38346d49e4638ec98649121d295d54
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.1.0-hd85de46_4.conda#9191d575b203fea7b901fa1391a772d8
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2026.1.0-hd85de46_4.conda#a62dce626d19df145aef38e790ea4b83
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2026.1.0-hd41364c_4.conda#95a9223e1ff6174a69d134a1ab805075
@@ -704,7 +696,7 @@ https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2026
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.1.0-hecca717_4.conda#b30fd90f32e047dc9363c882a34e926c
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.1.0-h78e8023_4.conda#3e08aabecc7cebfcc66ede56706b2b79
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.1.0-hecca717_4.conda#d8da10a17472a70071762e338a0d9977
-https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.2-h4c96295_0.conda#e318357f3d948cc16936d9f3b36cc7d9
+https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda#492c8d9b1c564c2e948b6cb4ba0f8261
 https://conda.anaconda.org/conda-forge/linux-64/libtensorflow_cc-2.19.1-cuda128h5d964f1_255.conda#9f3e4052e874422ea9701696ed3452e9
 https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda#9f6b0090c3902b2c763a16f7dace7b6e
 https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py312he3d6523_0.conda#7d499b5b6d150f133800dc3a582771c7
@@ -730,7 +722,7 @@ https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.5.0-py312hcedc861_0.c
 https://conda.anaconda.org/conda-forge/noarch/requests-cache-1.3.2-pyhd8ed1ab_0.conda#2b25a90124b8bbc7d01474dafecc815e
 https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-2.0.0-pyhd8ed1ab_1.conda#a283b764d8b155f81e904675ef5e1f4b
 https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.17.1-pyhd8ed1ab_0.conda#d2479d1f85954a6ffa96624a7f8f1aaa
-https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py312h3226591_1.conda#38decbeae260892040709cafc0514162
+https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py312h3226591_0.conda#e6e9b5795bb495325c3b4ebd451519aa
 https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda#cdd138897d94dc07d99afe7113a07bec
 https://conda.anaconda.org/conda-forge/noarch/sparse-0.18.0-pyhcf101f3_0.conda#c67d2c8ce612c88ece7221fe0b5357f2
 https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.6-py312h4f23490_0.conda#423b8676bd6eed60e97097b33f13ea3f
@@ -751,7 +743,7 @@ https://conda.anaconda.org/conda-forge/noarch/datashader-0.19.1-pyhd8ed1ab_0.con
 https://conda.anaconda.org/conda-forge/noarch/descartes-1.1.0-pyhd8ed1ab_5.conda#4a25cae637029c5589135903aa15b3b6
 https://conda.anaconda.org/conda-forge/linux-64/eccodes-2.47.0-ha1d8304_0.conda#3ef42f61d9a66a0749cbe598b5acdeea
 https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda#fc8b15af108a2fdb15ef04d12fbfe87d
-https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda#442ec6511754418c87a84bc1dc0c5384
+https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.24-pyhcf101f3_0.conda#517d72c5d62875c99fc0e6d4359a03f1
 https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.1.1-gpl_h1464181_102.conda#dca8e8993eb09c1a9bcb11fbe1187563
 https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.30.3-pyhcf101f3_0.conda#fc99cddcd8e6b37d975781e54f1770de
 https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.4.0-pyhd8ed1ab_0.conda#6e998cbb5c02e7aecdab93dd6b289ede
@@ -774,11 +766,10 @@ https://conda.anaconda.org/conda-forge/linux-64/msal_extensions-1.3.1-py312h7900
 https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda#00f5b8dafa842e0c27c1cd7296aa4875
 https://conda.anaconda.org/conda-forge/noarch/nbstripout-0.9.1-pyhd8ed1ab_0.conda#948b10290b9f4ebbb26de6da5c6b7c51
 https://conda.anaconda.org/conda-forge/noarch/nc-time-axis-1.4.1-pyhd8ed1ab_1.conda#9a2be7d0089f5934b550933ca0d9fe85
-https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-mpi_mpich_h67749c9_5.conda#fe8d6e0db37ccab85921a68868b9003b
+https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-nompi_h4a60669_105.conda#19c44fef9eba50f926770ee530742b10
 https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.4-nompi_py311h498b1eb_107.conda#7f5488cf61943e6221325b454c2c2e9c
 https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.5.1-pyhd8ed1ab_0.conda#aa2d1433efd557e9f49fd3b06081721f
 https://conda.anaconda.org/conda-forge/noarch/panel-core-1.9.3-pyha770c72_0.conda#7285b1299900255923435890ef95855b
-https://conda.anaconda.org/conda-forge/linux-64/parallelio-2.6.9-mpi_mpich_h462fbca_102.conda#61f401bc21aba557adbc3614b39bfa92
 https://conda.anaconda.org/conda-forge/noarch/pint-xarray-0.6.1-pyhd8ed1ab_0.conda#4315c8d39fd8b0541d7ff73c4cf91a8a
 https://conda.anaconda.org/conda-forge/noarch/planetary-computer-1.0.0-pyhd8ed1ab_1.conda#9477c2eb3a49f043c828384f277f29a6
 https://conda.anaconda.org/conda-forge/linux-64/pot-0.9.6.post1-py312hf79963d_0.conda#8547b23ed0dd4f4f83b5630abba00f1e
@@ -801,7 +792,7 @@ https://conda.anaconda.org/conda-forge/noarch/cdsapi-0.7.7-pyhd8ed1ab_0.conda#1f
 https://conda.anaconda.org/conda-forge/noarch/cf-xarray-0.11.1-pyhd8ed1ab_0.conda#10312a457c4756099f69fc3cbd330c1e
 https://conda.anaconda.org/conda-forge/noarch/chex-0.1.90-pyhd8ed1ab_0.conda#16d1408b8727d5cabb745b37b6a05207
 https://conda.anaconda.org/conda-forge/noarch/earthaccess-0.18.0-pyhc364b38_0.conda#3ec59d2fd5976f413d75463241b6eab7
-https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-mpi_mpich_ha43e4ac_103.conda#b4ed7c955c215d632bfb745304f84d04
+https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-nompi_h0c1e4bb_3.conda#acd2eee9535335dede2a9eed181251c5
 https://conda.anaconda.org/conda-forge/noarch/fastapi-0.136.3-h5ddb490_0.conda#966cdb82bffe2677a8bc33a458c05675
 https://conda.anaconda.org/conda-forge/noarch/fastprogress-1.1.6-pyhd8ed1ab_0.conda#74db9c154d80f3acf9ff3d7a8775fc57
 https://conda.anaconda.org/conda-forge/noarch/geopandas-1.1.3-pyhd8ed1ab_0.conda#4eb8b870142ca06d2a1d2c74662eac7d
@@ -816,14 +807,14 @@ https://conda.anaconda.org/conda-forge/linux-64/libparquet-23.0.1-h7376487_11_cp
 https://conda.anaconda.org/conda-forge/noarch/metpy-1.7.1-pyhd8ed1ab_0.conda#bdb9aebe518563d653773d0f91f51e6a
 https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda#2bce0d047658a91b99441390b9b27045
 https://conda.anaconda.org/conda-forge/noarch/odc-loader-0.6.4-pyhd8ed1ab_0.conda#c6768840997dad02d9e9dd7f3a05b56c
-https://conda.anaconda.org/conda-forge/noarch/orbax-checkpoint-0.11.40-pyhc364b38_0.conda#7447b63c97c9b61cc12c03b7f9b22b50
+https://conda.anaconda.org/conda-forge/noarch/orbax-checkpoint-0.12.0-pyhc364b38_0.conda#348b6b74ecbf5f69a735c03c41bcb69e
 https://conda.anaconda.org/conda-forge/noarch/panel-material-ui-0.11.2-pyhd8ed1ab_0.conda#b730b13aa613d911659ae6e27272701c
 https://conda.anaconda.org/conda-forge/linux-64/python-eccodes-2.47.0-np2py312hfb8c2c5_0.conda#614309c6287d4edebffa95dc983241d3
 https://conda.anaconda.org/conda-forge/noarch/rio-cogeo-7.0.2-pyhd8ed1ab_0.conda#0e48d784796728f7d9eef58b930a32d0
 https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda#62afb877ca2c2b4b6f9ecb37320085b6
 https://conda.anaconda.org/conda-forge/linux-64/tensorflow-base-2.19.1-cuda128py312ha24b813_255.conda#8aab43227442705c3b4172b58ab3b371
 https://conda.anaconda.org/conda-forge/linux-64/tiledb-py-0.36.1-py312h64554a1_0.conda#73277df2f161a6a2bb6cd7abd185b726
-https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.1-pyhd8ed1ab_0.conda#bcbb516ee86e84254906cc1aeb4b0216
+https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.2-pyhd8ed1ab_0.conda#235b842dd45d73f515394e640db614c5
 https://conda.anaconda.org/conda-forge/noarch/xgboost-3.2.0-cuda129_pyh5c66634_2.conda#aa47e29a69b6e7e2d3541749fbe11eb8
 https://conda.anaconda.org/conda-forge/noarch/xmip-0.7.2-pyhd8ed1ab_1.conda#ed2575dbbcac52e1f4c79669fdd7abce
 https://conda.anaconda.org/conda-forge/noarch/xvec-0.5.2-pyhd8ed1ab_0.conda#bc4fc627749c147b53cd847336fb00bd

--- a/ml-notebook/conda-lock.yml
+++ b/ml-notebook/conda-lock.yml
@@ -227,16 +227,16 @@ package:
   category: main
   optional: false
 - name: alsa-lib
-  version: 1.2.15.3
+  version: 1.2.16
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
   hash:
-    md5: dcdc58c15961dbf17a0621312b01f5cb
-    sha256: d88aa7ae766cf584e180996e92fef2aa7d8e0a0a5ab1d4d49c32390c1b5fff31
+    md5: 18d273b22e96c97c2017813f099faa82
+    sha256: 64484cb7e7cf65d9c7188498d595125a6e0751604dd7fb483e1bb327eec0f738
   category: main
   optional: false
 - name: amqp
@@ -879,7 +879,7 @@ package:
   category: main
   optional: false
 - name: awscli
-  version: 2.34.58
+  version: 2.34.60
   manager: conda
   platform: linux-64
   dependencies:
@@ -896,10 +896,10 @@ package:
     ruamel.yaml.clib: '>=0.2.0,<=0.2.15'
     urllib3: '>=1.25.4,<=2.6.3'
     wcwidth: <0.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.34.58-py312h20c3967_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.34.60-py312h20c3967_0.conda
   hash:
-    md5: 9c785409a34374d635bbdaf44345ed83
-    sha256: 5b5e7a6c284fb432dfc18b9de8e4b87efffa3b148a13be89b91c1551bf940c79
+    md5: b6573c0ff4ef231402878f918d28f41e
+    sha256: 5a313f960796561db57957cd815f6c2e8e3ee81d73a5c06161afb2b723db0604
   category: main
   optional: false
 - name: awscrt
@@ -2426,7 +2426,7 @@ package:
   category: main
   optional: false
 - name: debugpy
-  version: 1.8.20
+  version: 1.8.21
   manager: conda
   platform: linux-64
   dependencies:
@@ -2435,10 +2435,10 @@ package:
     libstdcxx: '>=14'
     python: ''
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py312h8285ef7_0.conda
   hash:
-    md5: ee1b48795ceb07311dd3e665dd4f5f33
-    sha256: f20121b67149ff80bf951ccae7442756586d8789204cd08ade59397b22bfd098
+    md5: e6778419a1851f6e15820558abddfa04
+    sha256: b8dbe25820064a099f315bbb8f45f5bac3fddb63e96af3cbf0c93a830733ef34
   category: main
   optional: false
 - name: decorator
@@ -2807,13 +2807,11 @@ package:
     libgfortran5: '>=14.3.0'
     libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libstdcxx: '>=14'
-    mpich: '>=5.0,<6.0a0'
     netcdf-fortran: '>=4.6.2,<4.7.0a0'
-    parallelio: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-mpi_mpich_ha43e4ac_103.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-nompi_h0c1e4bb_3.conda
   hash:
-    md5: b4ed7c955c215d632bfb745304f84d04
-    sha256: df29582456e3091ab5d0e7b7b2f1fd221dc829b8ca5603b45bc5fcd19d737bc5
+    md5: acd2eee9535335dede2a9eed181251c5
+    sha256: 7c91329051080f64fe81fd7346600bc07feaa60c102abc842f2b9b3c7a1d35aa
   category: main
   optional: false
 - name: esmpy
@@ -2889,19 +2887,19 @@ package:
   category: main
   optional: false
 - name: fastapi-cli
-  version: 0.0.23
+  version: 0.0.24
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
     rich-toolkit: '>=0.14.8'
     tomli: '>=2.0.0'
-    typer: '>=0.15.1'
+    typer: '>=0.16'
     uvicorn-standard: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.24-pyhcf101f3_0.conda
   hash:
-    md5: 442ec6511754418c87a84bc1dc0c5384
-    sha256: cb60fc8c96dcd2a6335914d4d6d7d5f5549c9e1ff4533be28ba699e648babf37
+    md5: 517d72c5d62875c99fc0e6d4359a03f1
+    sha256: 0c13b515d4424587b97dd6ede9277a659a1f580608faf3ab43341bf95a270aca
   category: main
   optional: false
 - name: fastapi-core
@@ -3255,7 +3253,7 @@ package:
   category: main
   optional: false
 - name: fontconfig
-  version: 2.18.0
+  version: 2.18.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -3266,10 +3264,10 @@ package:
     libgcc: '>=14'
     libuuid: '>=2.42.1,<3.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.0-h27c8c51_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
   hash:
-    md5: 06965b2f9854d0b15e0443ee81fe83dc
-    sha256: e798086d8a65d55dc4c51f5746705639c9a5f2eeb0b8fc50e6152cfc0d69a4e8
+    md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+    sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
   category: main
   optional: false
 - name: fonts-conda-ecosystem
@@ -3868,16 +3866,16 @@ package:
   category: main
   optional: false
 - name: google-cloud-sdk
-  version: 570.0.0
+  version: 571.0.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-570.0.0-py312h7900ff3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-571.0.0-py312h7900ff3_0.conda
   hash:
-    md5: c4663cdd2a4653c0a84f95a0227c9b8d
-    sha256: 9b00e1ac3dfd5a60c6d15c90f6f367e2a96d788c026358bdddae0ece489c3dcc
+    md5: dedf2ef75d0f01c92e73df4bfccb0a3c
+    sha256: 8c6beb9954409803f00fdbf31297645e85cae56136ca68d25d184a85be451fe8
   category: main
   optional: false
 - name: google-cloud-storage
@@ -3987,17 +3985,17 @@ package:
   category: main
   optional: false
 - name: graphite2
-  version: 1.3.14
+  version: 1.3.15
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
   hash:
-    md5: 2cd94587f3a401ae05e03a6caf09539d
-    sha256: 25ba37da5c39697a77fce2c9a15e48cf0a84f1464ad2aafbe53d8357a9f6cc8c
+    md5: cf09e9fc938518e91d0706572cadf17a
+    sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
   category: main
   optional: false
 - name: graphviz
@@ -4261,7 +4259,7 @@ package:
   category: main
   optional: false
 - name: harfbuzz
-  version: 14.2.0
+  version: 14.2.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -4269,17 +4267,17 @@ package:
     cairo: '>=1.18.4,<2.0a0'
     graphite2: '>=1.3.14,<2.0a0'
     icu: '>=78.3,<79.0a0'
-    libexpat: '>=2.7.5,<3.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libglib: '>=2.86.4,<3.0a0'
+    libglib: '>=2.88.1,<3.0a0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
   hash:
-    md5: e194f6a2f498f0c7b1e6498bd0b12645
-    sha256: 232c95b56d16d33d8256026a3b1ad34f7f9a75c179d388854be0fd624ddba9e3
+    md5: 21ee4640b7c2d94e584349fa12b29b9a
+    sha256: da9901aa1e20cbc2369fda212039b294dd02bce95f005539bab840b7310bf7d0
   category: main
   optional: false
 - name: hdf4
@@ -4316,12 +4314,11 @@ package:
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
     openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-mpi_mpich_h1a5cfed_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda
   hash:
-    md5: 847f1a715e324125f8e67cffeb9a7887
-    sha256: 1ac07a4d7404fd6255b6aefee3f98b98e2263c22214555342ec0715dc134e428
+    md5: 0d0595612fa229dddb5fc565c260a11f
+    sha256: beb8a2fb18924ca7b5b82cfb50f008f882f577daef2c00ed88022abea35fec76
   category: main
   optional: false
 - name: heapdict
@@ -6566,33 +6563,6 @@ package:
     sha256: 363018b25fdb5534c79783d912bd4b685a3547f4fc5996357ad548899b0ee8e7
   category: main
   optional: false
-- name: libfabric
-  version: 2.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libfabric1: 2.5.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.1-ha770c72_1.conda
-  hash:
-    md5: 0b82ff1ab3db9122f20cafe93f61bc3b
-    sha256: c2b53beed03c735b18116d5227410b15cc9fbef209795212afd179f8c8a5fd70
-  category: main
-  optional: false
-- name: libfabric1
-  version: 2.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    libgcc: '>=14'
-    libnl: '>=3.11.0,<4.0a0'
-    rdma-core: '>=63.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.1-h6b3ec72_1.conda
-  hash:
-    md5: 4a7168d686b6125ba546134dddb16721
-    sha256: f64b69e48636871081fde0604ed37fac32a7146073ad2899550bcc0b14e7c09d
-  category: main
-  optional: false
 - name: libffi
   version: 3.5.2
   manager: conda
@@ -7212,19 +7182,17 @@ package:
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.19.0,<9.0a0'
     libgcc: '>=14'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
     libstdcxx: '>=14'
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libzip: '>=1.11.2,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
     openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-mpi_mpich_h65e3e28_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_h3c9b436_104.conda
   hash:
-    md5: 5954d774093fd57ba35ad04265c22a9e
-    sha256: 02f09c75003e2bd6077821e331ec1e7c85789a99ddee0ccf7f9108add2244d7f
+    md5: 6d38346d49e4638ec98649121d295d54
+    sha256: 6a1dbee34abe246c32abb89bd35855c25551de09562a719da97c4e5975f5f035
   category: main
   optional: false
 - name: libnghttp2
@@ -7243,19 +7211,6 @@ package:
   hash:
     md5: 2a45e7f8af083626f009645a6481f12d
     sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
-  category: main
-  optional: false
-- name: libnl
-  version: 3.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
-  hash:
-    md5: db63358239cbe1ff86242406d440e44a
-    sha256: ba7c5d294e3d80f08ac5a39564217702d1a752e352e486210faff794ac5001b4
   category: main
   optional: false
 - name: libnsl
@@ -7633,23 +7588,6 @@ package:
     sha256: 26cbbd3d7b91801826c779c3f7e87d071856d5cbe3d55b22777ca0d984fb02ed
   category: main
   optional: false
-- name: libpnetcdf
-  version: 1.14.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libstdcxx: '>=14'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpnetcdf-1.14.1-mpi_mpich_h0009a5c_101.conda
-  hash:
-    md5: 2ec7034ce2c75d98ba3f73af3fecff08
-    sha256: 37bb953c0f6edeca52545dd4e43833348c3953be42d9c78315b4b0b627586c11
-  category: main
-  optional: false
 - name: libpng
   version: 1.6.58
   manager: conda
@@ -7696,13 +7634,13 @@ package:
   category: main
   optional: false
 - name: librsvg
-  version: 2.62.2
+  version: 2.62.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     cairo: '>=1.18.4,<2.0a0'
-    fontconfig: '>=2.17.1,<3.0a0'
+    fontconfig: '>=2.18.0,<3.0a0'
     fonts-conda-ecosystem: ''
     gdk-pixbuf: '>=2.44.6,<3.0a0'
     harfbuzz: '>=14.2.0'
@@ -7710,10 +7648,10 @@ package:
     libglib: '>=2.88.1,<3.0a0'
     libxml2-16: '>=2.14.6'
     pango: '>=1.56.4,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.2-h4c96295_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
   hash:
-    md5: e318357f3d948cc16936d9f3b36cc7d9
-    sha256: 864d93b0385778c7495c369d9df408e2b436ef136c8f7de645e25fd461acc553
+    md5: 492c8d9b1c564c2e948b6cb4ba0f8261
+    sha256: 5571bd8239d71961d4e3ce972f865b3ea95a91ce0b53d5749fe2dd24254ddbda
   category: main
   optional: false
 - name: librttopo
@@ -8790,38 +8728,6 @@ package:
     sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
   category: main
   optional: false
-- name: mpi
-  version: 1.0.1
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-mpich.conda
-  hash:
-    md5: 1052de900d672ec8b3713b8e300a8f06
-    sha256: eacc189267202669a1c5c849dcca2298f41acb3918f05cf912d7d61ee7176fac
-  category: main
-  optional: false
-- name: mpich
-  version: 5.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libfabric: ''
-    libfabric1: '>=1.14.0'
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libhwloc: '>=2.13.0,<2.13.1.0a0'
-    libstdcxx: '>=14'
-    mpi: 1.0.*
-    ucx: '>=1.20.0,<1.21.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpich-5.0.1-h6f9170e_0.conda
-  hash:
-    md5: 47a868b6ab372a8623f2a612d5979940
-    sha256: 6ebda028cde067c9effa285660e9c3e81361a700ac3b13d6b400ef9c4fbaa316
-  category: main
-  optional: false
 - name: mpmath
   version: 1.4.1
   manager: conda
@@ -9191,11 +9097,10 @@ package:
     libgfortran5: '>=14.3.0'
     libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-mpi_mpich_h67749c9_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-nompi_h4a60669_105.conda
   hash:
-    md5: fe8d6e0db37ccab85921a68868b9003b
-    sha256: 5226b4af7b4581e1fc0b02b93f7c2aeb68daa59a06dcf3271a4fc8c3b007e7ef
+    md5: 19c44fef9eba50f926770ee530742b10
+    sha256: 5df7a482cd3ed296fb56b3d4dca0755673f768e5fc244e27e44d5d8a9975e9ee
   category: main
   optional: false
 - name: netcdf4
@@ -9691,7 +9596,7 @@ package:
   category: main
   optional: false
 - name: orbax-checkpoint
-  version: 0.11.40
+  version: 0.12.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -9712,10 +9617,10 @@ package:
     tensorstore: '>=0.1.84'
     typing_extensions: ''
     uvloop: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/orbax-checkpoint-0.11.40-pyhc364b38_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/orbax-checkpoint-0.12.0-pyhc364b38_0.conda
   hash:
-    md5: 7447b63c97c9b61cc12c03b7f9b22b50
-    sha256: 5cad25156b0b4ce00cd6e501ab91f54f9f71f64d3d2dbbf575964e86365b673c
+    md5: 348b6b74ecbf5f69a735c03c41bcb69e
+    sha256: 9d598b5992d6a10aa536cff6d58cf478ea57a915f4a6aa57f11519cf9dcf2cda
   category: main
   optional: false
 - name: orc
@@ -9917,24 +9822,6 @@ package:
   hash:
     md5: d53ffc0edc8eabf4253508008493c5bc
     sha256: 315b52bfa6d1a820f4806f6490d472581438a28e21df175290477caec18972b0
-  category: main
-  optional: false
-- name: parallelio
-  version: 2.6.9
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libnetcdf: '>=4.10.0,<4.10.1.0a0'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/parallelio-2.6.9-mpi_mpich_h462fbca_102.conda
-  hash:
-    md5: 61f401bc21aba557adbc3614b39bfa92
-    sha256: 31d3f1efeaa55109c287f3930ca3627e377f699ad2571d714cbadd8784f8b7af
   category: main
   optional: false
 - name: param
@@ -11542,23 +11429,6 @@ package:
     sha256: f1625a3640e0a20af628b13551ccfe78747d68858b62c52e07576db6bb44ba1e
   category: main
   optional: false
-- name: rdma-core
-  version: '63.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libnl: '>=3.11.0,<4.0a0'
-    libstdcxx: '>=14'
-    libsystemd0: '>=257.13'
-    libudev1: '>=257.13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.0-h192683f_1.conda
-  hash:
-    md5: da47d3251c0f0d16b2801afe5a77b532
-    sha256: f0931894c751b22be09d7c976343a2957a14a59cfe0db04d916d1b93bd66ffcf
-  category: main
-  optional: false
 - name: re2
   version: 2025.11.05
   manager: conda
@@ -11949,24 +11819,25 @@ package:
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.8.0
+  version: 1.9.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-    joblib: '>=1.3.0'
+    joblib: '>=1.4.0'
     libgcc: '>=14'
     libstdcxx: '>=14'
+    narwhals: '>=2.0.1'
     numpy: '>=1.23,<3'
     python: ''
     python_abi: 3.12.*
     scipy: '>=1.10.0'
-    threadpoolctl: '>=3.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py312h3226591_1.conda
+    threadpoolctl: '>=3.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py312h3226591_0.conda
   hash:
-    md5: 38decbeae260892040709cafc0514162
-    sha256: 23c643c37fafa14ba3f2b7a407126ea5e732a3655ea8157cf9f977098f863448
+    md5: e6e9b5795bb495325c3b4ebd451519aa
+    sha256: 8c0cd0326b5a17ddcf189fc4f119bf6871b7853595c088075847c484a3ed567e
   category: main
   optional: false
 - name: scipy
@@ -12864,15 +12735,15 @@ package:
   category: main
   optional: false
 - name: traitlets
-  version: 5.15.0
+  version: 5.15.1
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
-    md5: 4bada6a6d908a27262af8ebddf4f7492
-    sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
+    md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+    sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
   category: main
   optional: false
 - name: traittypes
@@ -12923,19 +12794,19 @@ package:
   category: main
   optional: false
 - name: trollsift
-  version: 1.0.0
+  version: 1.0.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c9e0f517471f71f4a5ebac45ae3bbfa2
-    sha256: aa76ba7c535a4bcc297c9454bb9aeb873c1f8ad3b1e4c246908670ba7fd475c7
+    md5: f811b6bf76aba2311c448d5cedaaf080
+    sha256: 99a9f09f73df6bf374c240fc243acb0af3987f9d0725e5ed44215429e712f5b3
   category: main
   optional: false
 - name: typer
-  version: 0.26.5
+  version: 0.26.7
   manager: conda
   platform: linux-64
   dependencies:
@@ -12944,10 +12815,10 @@ package:
     python: ''
     rich: '>=13.8.0'
     shellingham: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
   hash:
-    md5: af2517b95781c326d315514ff1460453
-    sha256: 9ae0a38b5ccf9e2cb07f7fa4f7a5b070e4e0680831abf391b7fd1be296273319
+    md5: 71d2c80673511fab927bd15592994030
+    sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
   category: main
   optional: false
 - name: typing-extensions
@@ -13020,22 +12891,6 @@ package:
   hash:
     md5: 4fdd327852ffefc83173a7c029690d0c
     sha256: 9e5a0e70e876fca50de075b1cc6641cdc009a16c18f4d52ab03edb777729a1bc
-  category: main
-  optional: false
-- name: ucx
-  version: 1.20.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    rdma-core: '>=61.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.20.1-hbe80e26_0.conda
-  hash:
-    md5: 7d06bc10996e75c90b8cd7631b5dcf6c
-    sha256: 8f0ac4a92e4674eb4c87cdfc59d2fc7c2d0d1696689202eeb62ef715d82ce711
   category: main
   optional: false
 - name: ujson
@@ -13473,7 +13328,7 @@ package:
   category: main
   optional: false
 - name: xarray-spatial
-  version: 0.10.1
+  version: 0.10.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -13486,10 +13341,10 @@ package:
     urllib3: ''
     xarray: ''
     zstandard: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.2-pyhd8ed1ab_0.conda
   hash:
-    md5: bcbb516ee86e84254906cc1aeb4b0216
-    sha256: edf92d5609f2d5cc6ba510cc3584fdf55002c1f5c855b36bbd9a5e736a711163
+    md5: 235b842dd45d73f515394e640db614c5
+    sha256: df65d6a808619ca3b45aedeade36d6743a548db2979a64c5bf97734e7e9854ce
   category: main
   optional: false
 - name: xarray_leaflet

--- a/ml-notebook/environment.yml
+++ b/ml-notebook/environment.yml
@@ -11,4 +11,5 @@ dependencies:
  - jaxlib>=0.4.31=cuda12*
  - jupyterlab-nvdashboard
  - keras-cv
+ - python=3.12
  - tensorflow>=2.17.0=cuda12*

--- a/ml-notebook/packages.txt
+++ b/ml-notebook/packages.txt
@@ -14,7 +14,7 @@ aiohttp==3.13.5
 aioitertools==0.13.0
 aiosignal==1.4.0
 alembic==1.18.4
-alsa-lib==1.2.15.3
+alsa-lib==1.2.16
 amqp==5.3.1
 annotated-doc==0.0.4
 annotated-types==0.7.0
@@ -55,7 +55,7 @@ aws-c-sdkutils==0.2.4
 aws-checksums==0.2.10
 aws-crt-cpp==0.38.3
 aws-sdk-cpp==1.11.747
-awscli==2.34.58
+awscli==2.34.60
 awscrt==0.32.2
 azure-core==1.41.0
 azure-core-cpp==1.16.2
@@ -155,7 +155,7 @@ dask-ml==2025.1.0
 datashader==0.19.1
 dav1d==1.2.1
 dbus==1.16.2
-debugpy==1.8.20
+debugpy==1.8.21
 decorator==5.3.1
 defusedxml==0.7.1
 deprecated==1.3.1
@@ -185,7 +185,7 @@ etils==1.12.2
 exceptiongroup==1.3.1
 executing==2.2.1
 fastapi==0.136.3
-fastapi-cli==0.0.23
+fastapi-cli==0.0.24
 fastapi-core==0.136.3
 fastar==0.11.0
 fastcore==1.13.2
@@ -207,7 +207,7 @@ font-ttf-dejavu-sans-mono==2.37
 font-ttf-inconsolata==3.000
 font-ttf-source-code-pro==2.038
 font-ttf-ubuntu==0.83
-fontconfig==2.18.0
+fontconfig==2.18.1
 fonts-conda-ecosystem==1
 fonts-conda-forge==1
 fonttools==4.63.0
@@ -247,7 +247,7 @@ google-api-core==2.30.3
 google-auth==2.53.0
 google-auth-oauthlib==1.4.0
 google-cloud-core==2.5.1
-google-cloud-sdk==570.0.0
+google-cloud-sdk==571.0.0
 google-cloud-storage==3.10.1
 google-cloud-storage-control==1.10.0
 google-crc32c==1.8.0
@@ -255,7 +255,7 @@ google-pasta==0.2.0
 google-resumable-media==2.8.0
 googleapis-common-protos==1.75.0
 googleapis-common-protos-grpc==1.75.0
-graphite2==1.3.14
+graphite2==1.3.15
 graphviz==14.1.2
 greenlet==3.5.1
 grpc-google-iam-v1==0.14.4
@@ -270,7 +270,7 @@ h3==4.4.1
 h3-py==4.4.1
 h5netcdf==1.8.1
 h5py==3.16.0
-harfbuzz==14.2.0
+harfbuzz==14.2.1
 hdf4==4.2.15
 hdf5==2.1.0
 heapdict==1.0.1
@@ -413,8 +413,6 @@ libegl-devel==1.7.0
 libev==4.33
 libevent==2.1.12
 libexpat==2.8.1
-libfabric==2.5.1
-libfabric1==2.5.1
 libffi==3.5.2
 libfido2==1.17.0
 libflac==1.5.0
@@ -455,7 +453,6 @@ liblzma==5.8.3
 libml_dtypes-headers==0.5.4
 libnetcdf==4.10.0
 libnghttp2==1.68.1
-libnl==3.11.0
 libnsl==2.0.1
 libnvjitlink==12.9.86
 libogg==1.3.5
@@ -480,11 +477,10 @@ libopus==1.6.1
 libparquet==23.0.1
 libpciaccess==0.19
 libplacebo==7.360.1
-libpnetcdf==1.14.1
 libpng==1.6.58
 libprotobuf==6.33.5
 libre2-11==2025.11.05
-librsvg==2.62.2
+librsvg==2.62.3
 librttopo==1.1.0
 libsecret==0.21.7
 libsndfile==1.2.2
@@ -550,8 +546,6 @@ mistune==3.2.1
 ml_dtypes==0.5.4
 morecantile==7.0.3
 mpg123==1.32.9
-mpi==1.0.1
-mpich==5.0.1
 mpmath==1.4.1
 msal==1.37.0
 msal_extensions==1.3.1
@@ -608,7 +602,7 @@ openssl==3.6.2
 opt_einsum==3.4.0
 optax==0.2.8
 optree==0.19.1
-orbax-checkpoint==0.11.40
+orbax-checkpoint==0.12.0
 orc==2.3.0
 overrides==7.7.0
 packaging==26.2
@@ -621,7 +615,6 @@ panel-material-ui==0.11.2
 pangeo-dask==2026.01.21
 pangeo-notebook==2026.01.21
 pango==1.56.4
-parallelio==2.6.9
 param==2.4.0
 parso==0.8.7
 partd==1.4.2
@@ -728,7 +721,6 @@ qhull==2020.2
 rasterio==1.5.0
 rav1e==0.8.1
 rclone==1.74.2
-rdma-core==63.0
 re2==2025.11.05
 readline==8.3
 rechunker==0.5.2
@@ -754,7 +746,7 @@ s3fs==2026.4.0
 s3transfer==0.17.1
 satpy==0.60.0
 scikit-image==0.26.0
-scikit-learn==1.8.0
+scikit-learn==1.9.0
 scipy==1.17.1
 sdl2==2.32.56
 sdl3==3.4.10
@@ -810,19 +802,18 @@ tomli==2.4.1
 toolz==1.1.0
 tornado==6.5.6
 tqdm==4.67.3
-traitlets==5.15.0
+traitlets==5.15.1
 traittypes==0.2.3
 treescope==0.1.10
 trollimage==1.28.0
-trollsift==1.0.0
-typer==0.26.5
+trollsift==1.0.1
+typer==0.26.7
 typing-extensions==4.15.0
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 typing_utils==0.1.0
 tzdata==2025c
 uc-micro-py==2.0.0
-ucx==1.20.1
 ujson==5.12.1
 uncompresspy==0.4.1
 unicodedata2==17.0.1
@@ -854,7 +845,7 @@ wrapt==2.2.1
 x264==1%21164.3095
 x265==3.5
 xarray==2026.4.0
-xarray-spatial==0.10.1
+xarray-spatial==0.10.2
 xarray_leaflet==0.2.3
 xarrayutils==2.0.1
 xbatcher==0.4.0

--- a/pangeo-notebook/conda-linux-64.lock
+++ b/pangeo-notebook/conda-linux-64.lock
@@ -10,7 +10,6 @@ https://conda.anaconda.org/conda-forge/linux-64/gh-2.93.0-hfc2019e_0.conda#c4573
 https://conda.anaconda.org/conda-forge/linux-64/git-lfs-3.7.1-ha8f183a_1.conda#185f332b1a60ed24701358bb3c21aee2
 https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda#129e404c5b001f3ef5581316971e3ea0
 https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_0.conda#f8dcb0cff8f84f428bf76f1169bf50a7
-https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-mpich.conda#1052de900d672ec8b3713b8e300a8f06
 https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda#16c2a0e9c4a166e53632cfca4f68d020
 https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda#c3efd25ac4d74b1584d2f7a57195ddf1
 https://conda.anaconda.org/conda-forge/linux-64/rclone-1.74.2-h519d9b9_0.conda#cceb9ab8d52b42cd74485929f86ba207
@@ -29,7 +28,7 @@ https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda#c2a0
 https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda#4a13eeac0b5c8e5b8ab496e6c4ddd829
 https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda#18335a698559cdbcd86150a48bf54ba6
 https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda#57736f29cc2b0ec0b6c2952d3f101b6a
-https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda#dcdc58c15961dbf17a0621312b01f5cb
+https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda#18d273b22e96c97c2017813f099faa82
 https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda#e36ad70a7e0b48f091ed6902f04c23b8
 https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda#d2ffd7602c02f2b316fd921d39876885
 https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda#920bb03579f15389b9e512095ad995b7
@@ -47,7 +46,6 @@ https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.
 https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda#915f5995e94f60e9a4826e0b0920ee88
 https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda#6178c6f2fb254558238ef4e6c56fb782
 https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda#b88d90cad08e6bc8ad540cb310a761fb
-https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda#db63358239cbe1ff86242406d440e44a
 https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda#d864d34357c3b65a4b731f78c0801dc4
 https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda#68e52064ed3897463c0e958ab5c8f91b
 https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda#2446ac1fe030c2aa6141386c1f5a6aed
@@ -83,7 +81,7 @@ https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda#f7d7
 https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda#4d4efd0645cd556fab54617c4ad477ef
 https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda#d411fc29e338efb48c5fd4576d71d881
 https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda#3bf7b9fd5a7136126e0234db4b87c8b6
-https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda#2cd94587f3a401ae05e03a6caf09539d
+https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda#cf09e9fc938518e91d0706572cadf17a
 https://conda.anaconda.org/conda-forge/linux-64/h3-4.3.0-h3e4d06c_1.conda#7a9b1ee49ab4ac8ee2a0bda9e9f666d5
 https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda#c80d8a3b84358cb967fa81e7075fbc8a
 https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda#10909406c1b0e4b57f9f4f0eb0999af8
@@ -169,7 +167,6 @@ https://conda.anaconda.org/conda-forge/linux-64/libzopfli-1.0.3-h9c3ff4c_0.tar.b
 https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.4-hb03c661_1.conda#c2871ba95727fd1382c05db66048b64c
 https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda#7eccb41177e15cc672e1babe9056018e
 https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda#353823361b1d27eb3960efb076dfcaf6
-https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.0-h192683f_1.conda#da47d3251c0f0d16b2801afe5a77b532
 https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.17.0-hab81395_1.conda#a3b0e874fa56f72bc54e5c595712a333
 https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.1-hbc0de68_0.conda#8e0b8654ead18e50af552e54b5a08a61
 https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda#d71d3a66528853c0a1ac2c02d79a0284
@@ -208,7 +205,7 @@ https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda#2da1
 https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda#f54c1ffb8ecedb85a8b7fcde3a187212
 https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda#4c2a8fef270f6c69591889b93f9f55c1
 https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda#ce96f2f470d39bd96ce03945af92e280
-https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda#ee1b48795ceb07311dd3e665dd4f5f33
+https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py312h8285ef7_0.conda#e6778419a1851f6e15820558abddfa04
 https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda#61dcf784d59ef0bd62c57d982b154ace
 https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2#961b3a227b437d82ad7054484cfa71b2
 https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda#67999c5465064480fa8016d00ac768f6
@@ -220,7 +217,7 @@ https://conda.anaconda.org/conda-forge/linux-64/fastar-0.11.0-py312h42cbcb6_0.co
 https://conda.anaconda.org/conda-forge/noarch/fastcore-1.13.2-pyhcf101f3_0.conda#84fc5b6dc5de080478b3dd30c212ad6a
 https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda#8fa8358d022a3a9bd101384a808044c6
 https://conda.anaconda.org/conda-forge/noarch/findlibs-0.1.2-pyhd8ed1ab_0.conda#fa9e9ec7bf26619a8edd3e11155f15d6
-https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.0-h27c8c51_0.conda#06965b2f9854d0b15e0443ee81fe83dc
+https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda#e0e050cfa9fa85fe39632ab11cb7f3e0
 https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda#8462b5322567212beeb025f3519fb3e2
 https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.8.0-py312h447239a_0.conda#6a42923f35087cc88a9fac31ef096ce6
 https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda#2c11aa96ea85ced419de710c1c3a78ff
@@ -229,7 +226,7 @@ https://conda.anaconda.org/conda-forge/noarch/gast-0.7.0-pyhd8ed1ab_0.conda#377a
 https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda#7892f39a39ed39591a89a28eba03e987
 https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.1-pyhd8ed1ab_0.conda#43dd16b113cc7b244d923b630026ff4f
 https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.1-hee1de02_2.conda#e5a459d2bb98edb88de5a44bfad66b9d
-https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-570.0.0-py312h7900ff3_0.conda#c4663cdd2a4653c0a84f95a0227c9b8d
+https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-571.0.0-py312h7900ff3_0.conda#dedf2ef75d0f01c92e73df4bfccb0a3c
 https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py312h03f33d3_1.conda#68f704ea294dcec9e09edd9c3d233846
 https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.1-py312h8285ef7_0.conda#3a704672326e552b019390d832a4b095
 https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda#4d8df0b0db060d33c9a702ada998a8fe
@@ -254,7 +251,6 @@ https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.4.2-hcfa2d63_0.conda
 https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda#00fc660ab1b2f5ca07e92b4900d10c79
 https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda#49c553b47ff679a6a1e9fc80b9c5a2d4
 https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda#c3cc2864f82a944bc90a7beb4d3b0e88
-https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.1-h6b3ec72_1.conda#4a7168d686b6125ba546134dddb16721
 https://conda.anaconda.org/conda-forge/linux-64/libfido2-1.17.0-h8c08ba8_0.conda#f3a2fbd4644599669d5f274f98c04b30
 https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda#ec3c4350aa0261bf7f87b8ca15c8e80e
 https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-haa4a5bd_1023.conda#953b7cca897e21215302dbfe2af5cd0c
@@ -335,12 +331,11 @@ https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda#b53
 https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda#c07a6153f8306e45794774cf9b13bd32
 https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.6-py312h4c3975b_0.conda#dcbe46475eff6fb9d1adad473c984f39
 https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda#e5ce43272193b38c2e9037446c1d9206
-https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda#4bada6a6d908a27262af8ebddf4f7492
-https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.0-pyhd8ed1ab_0.conda#c9e0f517471f71f4a5ebac45ae3bbfa2
+https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda#37e3be7b6e2977d37b8fa5da229f5dc0
+https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.1-pyhd8ed1ab_0.conda#f811b6bf76aba2311c448d5cedaaf080
 https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda#0caa1af407ecff61170c9437a808404d
 https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda#f6d7aa696c67756a650e91e15e88223c
 https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-2.0.0-pyhcf101f3_0.conda#4fdd327852ffefc83173a7c029690d0c
-https://conda.anaconda.org/conda-forge/linux-64/ucx-1.20.1-hbe80e26_0.conda#7d06bc10996e75c90b8cd7631b5dcf6c
 https://conda.anaconda.org/conda-forge/linux-64/ujson-5.12.1-py312h8285ef7_1.conda#1a16c1e03a6d960a183086adabd4a52a
 https://conda.anaconda.org/conda-forge/noarch/uncompresspy-0.4.1-pyhd8ed1ab_0.conda#06de15bda7ff6019d8e02e6682664b63
 https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda#0b6c506ec1f272b685240e70a29261b8
@@ -408,7 +403,6 @@ https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1
 https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda#75932da6f03a6bef32b70a51e991f6eb
 https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.7-gpl_hc2c16d8_101.conda#bb1483d91797dae0b466cab86ceb59a7
 https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda#33a413f1095f8325e5c30fde3b0d2445
-https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.1-ha770c72_1.conda#0b82ff1ab3db9122f20cafe93f61bc3b
 https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h5fbf134_12.conda#88c1c66987cd52a712eea89c27104be6
 https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda#f25206d7322c0e9648e8b83694d143ab
 https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda#16b6330783ce0d1ae8d22782173b32c9
@@ -499,7 +493,7 @@ https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda#d354
 https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-h215f996_4.conda#b39dccf5af984bcb68ee2aa0f3213ea6
 https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.50-pyhd8ed1ab_0.conda#98958318a01373a615f119b1040b3027
 https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.78.1-py312h39ee1c6_0.conda#b1995dadc14463d8f914c54cf2061a07
-https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda#e194f6a2f498f0c7b1e6498bd0b12645
+https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda#21ee4640b7c2d94e584349fa12b29b9a
 https://conda.anaconda.org/conda-forge/noarch/importlib-resources-7.1.0-pyhd8ed1ab_0.conda#e3bffa82b874f8b9a2631bddb3869529
 https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.0-pyh53cf698_0.conda#8e3caf9b45475eb00053f4bb60be0d15
 https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda#439cd0f567d697b20a8f45cb70a1005a
@@ -514,7 +508,6 @@ https://conda.anaconda.org/conda-forge/linux-64/lxml-6.1.1-py312h63ddcf0_0.conda
 https://conda.anaconda.org/conda-forge/noarch/mako-1.3.12-pyhcf101f3_0.conda#a73036dabdd6dfe9679ed893baa8b230
 https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.2-pyhcf101f3_0.conda#ba0a9221ce1063f31692c07370d062f3
 https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda#ad6821df7a98510117db06e9a833281f
-https://conda.anaconda.org/conda-forge/linux-64/mpich-5.0.1-h6f9170e_0.conda#47a868b6ab372a8623f2a612d5979940
 https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.6-py312h33ff503_0.conda#6e31d55ee1110fda83b4f4045f4d73ff
 https://conda.anaconda.org/conda-forge/noarch/obspec_utils-0.9.0-pyhd8ed1ab_0.conda#3289f38214d30fa6f32540d3fcb7c278
 https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh8b19718_0.conda#511fbc2c63d2c73650ad1755e4d357ba
@@ -554,7 +547,7 @@ https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-grpc-1.75
 https://conda.anaconda.org/conda-forge/noarch/grpcio-status-1.78.1-pyhcf101f3_0.conda#829271a8ea9d8024e99e43939ebb114f
 https://conda.anaconda.org/conda-forge/linux-64/gsw-3.6.21-py312h5253ce2_0.conda#6854d74d7179915efa7f044b9fe0d39b
 https://conda.anaconda.org/conda-forge/linux-64/h3-py-4.3.0-py312h8285ef7_3.conda#4f64388450cd2836069c37692c09aad5
-https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-mpi_mpich_h1a5cfed_5.conda#847f1a715e324125f8e67cffeb9a7887
+https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda#0d0595612fa229dddb5fc565c260a11f
 https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda#4f14640d58e2cc0aa0819d9d8ba125bb
 https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2026.5.10-py312h7d53d09_1.conda#30450910826efe1f291ce643a283a52c
 https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda#b5577bc2212219566578fd5af9993af6
@@ -571,7 +564,6 @@ https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.3-he63569f_3.c
 https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda#8ae0593085ca8148fdbf0bc8f62e79c1
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2026.1.0-hb56ce9e_4.conda#bf0b7cde9e67d746db3dac68b563de77
 https://conda.anaconda.org/conda-forge/linux-64/libplacebo-7.360.1-h9eeb4b2_0.conda#e6324dfe6c02e0736bb9235f8ef3c8a6
-https://conda.anaconda.org/conda-forge/linux-64/libpnetcdf-1.14.1-mpi_mpich_h0009a5c_101.conda#2ec7034ce2c75d98ba3f73af3fecff08
 https://conda.anaconda.org/conda-forge/noarch/lsprotocol-2025.0.0-pyhe01879c_0.conda#f0680112562ae328ef9ce60545879cf9
 https://conda.anaconda.org/conda-forge/linux-64/nh3-0.3.5-py310hd8a072f_1.conda#8719dd226e9a128bd10033746e2418c6
 https://conda.anaconda.org/conda-forge/linux-64/numba-0.65.1-py312hd1dde6f_1.conda#acd0d3547b3cb443a5ce9124412b6295
@@ -597,7 +589,7 @@ https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.4.10-hdeec2a5_0.conda#845
 https://conda.anaconda.org/conda-forge/linux-64/shapely-2.1.2-py312h383787d_2.conda#69e400d3deca12ee7afd4b73a5596905
 https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda#9aa358575bbd4be126eaa5e0039f835c
 https://conda.anaconda.org/conda-forge/noarch/starlette-1.2.1-pyhcf101f3_0.conda#42f2b5375c39905cf8b020bbd85f687b
-https://conda.anaconda.org/conda-forge/noarch/typer-0.26.5-pyhcf101f3_0.conda#af2517b95781c326d315514ff1460453
+https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda#71d2c80673511fab927bd15592994030
 https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.2.0-py312h0ccc70a_0.conda#331d2437900a5e2d54641308d3445236
 https://conda.anaconda.org/conda-forge/noarch/watermark-2.6.0-pyhcf101f3_0.conda#05030c85ab3ec75ed1f9eb2b7fd62a74
 https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda#39f70aca52f1497a72eb9d81baf4d237
@@ -605,7 +597,7 @@ https://conda.anaconda.org/conda-forge/noarch/anywidget-0.11.0-pyhd8ed1ab_0.cond
 https://conda.anaconda.org/conda-forge/linux-64/astropy-base-7.2.0-py312h4f23490_0.conda#a2826f4e9101450669fcfbe1b3b16820
 https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2#6b889f174df1e0f816276ae69281af4d
 https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.747-h41c0014_4.conda#169a79ea1127077d8dc36dc963ff55ac
-https://conda.anaconda.org/conda-forge/linux-64/awscli-2.34.58-py312h20c3967_0.conda#9c785409a34374d635bbdaf44345ed83
+https://conda.anaconda.org/conda-forge/linux-64/awscli-2.34.60-py312h20c3967_0.conda#b6573c0ff4ef231402878f918d28f41e
 https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.15.0-h1e5b466_0.conda#c9186aa979528963657db3e63c25e987
 https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.0-pyhd8ed1ab_0.conda#b9a6da57e94cd12bd71e7ab0713ef052
 https://conda.anaconda.org/conda-forge/noarch/bqscales-0.3.7-pyhd8ed1ab_1.conda#5325324a656c5490644fc3961e681ab6
@@ -631,7 +623,7 @@ https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.8.0-pyhcf101f3_0.
 https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.3-hf70aa56_3.conda#5429ab06028218ac67e11695b4b66a96
 https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.3-ha9bf034_3.conda#f019b2a48a736bf0357b0e24176ab941
 https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda#6f79d5f72cfcdd3509112233a8aedc2e
-https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-mpi_mpich_h65e3e28_4.conda#5954d774093fd57ba35ad04265c22a9e
+https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_h3c9b436_104.conda#6d38346d49e4638ec98649121d295d54
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.1.0-hd85de46_4.conda#9191d575b203fea7b901fa1391a772d8
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2026.1.0-hd85de46_4.conda#a62dce626d19df145aef38e790ea4b83
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2026.1.0-hd41364c_4.conda#95a9223e1ff6174a69d134a1ab805075
@@ -644,7 +636,7 @@ https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2026
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.1.0-hecca717_4.conda#b30fd90f32e047dc9363c882a34e926c
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.1.0-h78e8023_4.conda#3e08aabecc7cebfcc66ede56706b2b79
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.1.0-hecca717_4.conda#d8da10a17472a70071762e338a0d9977
-https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.2-h4c96295_0.conda#e318357f3d948cc16936d9f3b36cc7d9
+https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda#492c8d9b1c564c2e948b6cb4ba0f8261
 https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda#9f6b0090c3902b2c763a16f7dace7b6e
 https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py312he3d6523_0.conda#7d499b5b6d150f133800dc3a582771c7
 https://conda.anaconda.org/conda-forge/noarch/msal-1.37.0-pyhd8ed1ab_0.conda#539593f9c2174c98c79cabe16fd25157
@@ -669,7 +661,7 @@ https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.5.0-py312hcedc861_0.c
 https://conda.anaconda.org/conda-forge/noarch/requests-cache-1.3.2-pyhd8ed1ab_0.conda#2b25a90124b8bbc7d01474dafecc815e
 https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-2.0.0-pyhd8ed1ab_1.conda#a283b764d8b155f81e904675ef5e1f4b
 https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.17.1-pyhd8ed1ab_0.conda#d2479d1f85954a6ffa96624a7f8f1aaa
-https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py312h3226591_1.conda#38decbeae260892040709cafc0514162
+https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py312h3226591_0.conda#e6e9b5795bb495325c3b4ebd451519aa
 https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda#cdd138897d94dc07d99afe7113a07bec
 https://conda.anaconda.org/conda-forge/noarch/sparse-0.18.0-pyhcf101f3_0.conda#c67d2c8ce612c88ece7221fe0b5357f2
 https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.6-py312h4f23490_0.conda#423b8676bd6eed60e97097b33f13ea3f
@@ -689,7 +681,7 @@ https://conda.anaconda.org/conda-forge/noarch/datashader-0.19.1-pyhd8ed1ab_0.con
 https://conda.anaconda.org/conda-forge/noarch/descartes-1.1.0-pyhd8ed1ab_5.conda#4a25cae637029c5589135903aa15b3b6
 https://conda.anaconda.org/conda-forge/linux-64/eccodes-2.47.0-ha1d8304_0.conda#3ef42f61d9a66a0749cbe598b5acdeea
 https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda#fc8b15af108a2fdb15ef04d12fbfe87d
-https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda#442ec6511754418c87a84bc1dc0c5384
+https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.24-pyhcf101f3_0.conda#517d72c5d62875c99fc0e6d4359a03f1
 https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.1.1-gpl_h58043d5_902.conda#844d3b4dbea878ef081aef26f3801f2f
 https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.30.3-pyhcf101f3_0.conda#fc99cddcd8e6b37d975781e54f1770de
 https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.4.0-pyhd8ed1ab_0.conda#6e998cbb5c02e7aecdab93dd6b289ede
@@ -709,11 +701,10 @@ https://conda.anaconda.org/conda-forge/linux-64/msal_extensions-1.3.1-py312h7900
 https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda#00f5b8dafa842e0c27c1cd7296aa4875
 https://conda.anaconda.org/conda-forge/noarch/nbstripout-0.9.1-pyhd8ed1ab_0.conda#948b10290b9f4ebbb26de6da5c6b7c51
 https://conda.anaconda.org/conda-forge/noarch/nc-time-axis-1.4.1-pyhd8ed1ab_1.conda#9a2be7d0089f5934b550933ca0d9fe85
-https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-mpi_mpich_h67749c9_5.conda#fe8d6e0db37ccab85921a68868b9003b
+https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-nompi_h4a60669_105.conda#19c44fef9eba50f926770ee530742b10
 https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.4-nompi_py311h498b1eb_107.conda#7f5488cf61943e6221325b454c2c2e9c
 https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.5.1-pyhd8ed1ab_0.conda#aa2d1433efd557e9f49fd3b06081721f
 https://conda.anaconda.org/conda-forge/noarch/panel-core-1.9.3-pyha770c72_0.conda#7285b1299900255923435890ef95855b
-https://conda.anaconda.org/conda-forge/linux-64/parallelio-2.6.9-mpi_mpich_h462fbca_102.conda#61f401bc21aba557adbc3614b39bfa92
 https://conda.anaconda.org/conda-forge/noarch/pint-xarray-0.6.1-pyhd8ed1ab_0.conda#4315c8d39fd8b0541d7ff73c4cf91a8a
 https://conda.anaconda.org/conda-forge/noarch/planetary-computer-1.0.0-pyhd8ed1ab_1.conda#9477c2eb3a49f043c828384f277f29a6
 https://conda.anaconda.org/conda-forge/linux-64/pot-0.9.6.post1-py312hf79963d_0.conda#8547b23ed0dd4f4f83b5630abba00f1e
@@ -735,7 +726,7 @@ https://conda.anaconda.org/conda-forge/linux-64/av-17.0.1-py312h46547aa_0.conda#
 https://conda.anaconda.org/conda-forge/noarch/cdsapi-0.7.7-pyhd8ed1ab_0.conda#1f878573c1ee2798c052bee1f5a94f50
 https://conda.anaconda.org/conda-forge/noarch/cf-xarray-0.11.1-pyhd8ed1ab_0.conda#10312a457c4756099f69fc3cbd330c1e
 https://conda.anaconda.org/conda-forge/noarch/earthaccess-0.18.0-pyhc364b38_0.conda#3ec59d2fd5976f413d75463241b6eab7
-https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-mpi_mpich_ha43e4ac_103.conda#b4ed7c955c215d632bfb745304f84d04
+https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-nompi_h0c1e4bb_3.conda#acd2eee9535335dede2a9eed181251c5
 https://conda.anaconda.org/conda-forge/noarch/fastapi-0.136.3-h5ddb490_0.conda#966cdb82bffe2677a8bc33a458c05675
 https://conda.anaconda.org/conda-forge/noarch/fastprogress-1.1.6-pyhd8ed1ab_0.conda#74db9c154d80f3acf9ff3d7a8775fc57
 https://conda.anaconda.org/conda-forge/noarch/geopandas-1.1.3-pyhd8ed1ab_0.conda#4eb8b870142ca06d2a1d2c74662eac7d
@@ -755,7 +746,7 @@ https://conda.anaconda.org/conda-forge/linux-64/python-eccodes-2.47.0-np2py312hf
 https://conda.anaconda.org/conda-forge/noarch/rio-cogeo-7.0.2-pyhd8ed1ab_0.conda#0e48d784796728f7d9eef58b930a32d0
 https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda#62afb877ca2c2b4b6f9ecb37320085b6
 https://conda.anaconda.org/conda-forge/linux-64/tiledb-py-0.36.1-py312h64554a1_0.conda#73277df2f161a6a2bb6cd7abd185b726
-https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.1-pyhd8ed1ab_0.conda#bcbb516ee86e84254906cc1aeb4b0216
+https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.2-pyhd8ed1ab_0.conda#235b842dd45d73f515394e640db614c5
 https://conda.anaconda.org/conda-forge/noarch/xgboost-3.2.0-cpu_pyhb39878e_2.conda#f070d4425ed26796a7b344a71e0cb66f
 https://conda.anaconda.org/conda-forge/noarch/xmip-0.7.2-pyhd8ed1ab_1.conda#ed2575dbbcac52e1f4c79669fdd7abce
 https://conda.anaconda.org/conda-forge/noarch/xvec-0.5.2-pyhd8ed1ab_0.conda#bc4fc627749c147b53cd847336fb00bd

--- a/pangeo-notebook/conda-lock.yml
+++ b/pangeo-notebook/conda-lock.yml
@@ -688,28 +688,28 @@ package:
   category: main
   optional: false
 - name: alsa-lib
-  version: 1.2.15.3
+  version: 1.2.16
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
   hash:
-    md5: dcdc58c15961dbf17a0621312b01f5cb
-    sha256: d88aa7ae766cf584e180996e92fef2aa7d8e0a0a5ab1d4d49c32390c1b5fff31
+    md5: 18d273b22e96c97c2017813f099faa82
+    sha256: 64484cb7e7cf65d9c7188498d595125a6e0751604dd7fb483e1bb327eec0f738
   category: main
   optional: false
 - name: alsa-lib
-  version: 1.2.15.3
+  version: 1.2.16
   manager: conda
   platform: linux-aarch64
   dependencies:
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.15.3-he30d5cf_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.16-he30d5cf_0.conda
   hash:
-    md5: 4a98cbc4ade694520227402ff8880630
-    sha256: ea2233e2db9908c2e5f29d3ca420a546b4583253f4f70abb5494cdd676866d42
+    md5: 20e118f10dc11b6b2383ae7c1f2c8e8c
+    sha256: 722a24bb4a2faabcedf694ae494393e6f9b698dddbf0782fb0dcd7bfcc0c2027
   category: main
   optional: false
 - name: amqp
@@ -3082,7 +3082,7 @@ package:
   category: main
   optional: false
 - name: awscli
-  version: 2.34.58
+  version: 2.34.60
   manager: conda
   platform: linux-64
   dependencies:
@@ -3099,14 +3099,14 @@ package:
     ruamel.yaml.clib: '>=0.2.0,<=0.2.15'
     urllib3: '>=1.25.4,<=2.6.3'
     wcwidth: <0.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.34.58-py312h20c3967_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.34.60-py312h20c3967_0.conda
   hash:
-    md5: 9c785409a34374d635bbdaf44345ed83
-    sha256: 5b5e7a6c284fb432dfc18b9de8e4b87efffa3b148a13be89b91c1551bf940c79
+    md5: b6573c0ff4ef231402878f918d28f41e
+    sha256: 5a313f960796561db57957cd815f6c2e8e3ee81d73a5c06161afb2b723db0604
   category: main
   optional: false
 - name: awscli
-  version: 2.34.58
+  version: 2.34.60
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -3123,14 +3123,14 @@ package:
     ruamel.yaml.clib: '>=0.2.0,<=0.2.15'
     urllib3: '>=1.25.4,<=2.6.3'
     wcwidth: <0.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/awscli-2.34.58-py312h6d8504a_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/awscli-2.34.60-py312h6d8504a_0.conda
   hash:
-    md5: 16ce6bfb777be8b6d5c770d0c040efbc
-    sha256: fcbc2a81db3634c7ff550d75d155558b99f6e44649c62d2534080096cb6785fe
+    md5: 28b82d44c15d5466d4ecb9f1502785f2
+    sha256: 2edac0ec78afb1b2348b337843428b9e555a34c588e47bf549927605899aad6a
   category: main
   optional: false
 - name: awscli
-  version: 2.34.58
+  version: 2.34.60
   manager: conda
   platform: osx-64
   dependencies:
@@ -3147,14 +3147,14 @@ package:
     ruamel.yaml.clib: '>=0.2.0,<=0.2.15'
     urllib3: '>=1.25.4,<=2.6.3'
     wcwidth: <0.3.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/awscli-2.34.58-py312hc2fe966_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/awscli-2.34.60-py312hc2fe966_0.conda
   hash:
-    md5: b527271602c7d7b72963ab22a042b954
-    sha256: eba0b37dce18f6b18d556af82489b5bff6a9ab258dcaca3b76db714012c84692
+    md5: 7eb99a7d36851202fe54f687e54f01db
+    sha256: c2b40204a795a27832cb44066410aa445f186ef0acdce6ff057b676d7cf5d0ab
   category: main
   optional: false
 - name: awscli
-  version: 2.34.58
+  version: 2.34.60
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3171,10 +3171,10 @@ package:
     ruamel.yaml.clib: '>=0.2.0,<=0.2.15'
     urllib3: '>=1.25.4,<=2.6.3'
     wcwidth: <0.3.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/awscli-2.34.58-py312hc28c600_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/awscli-2.34.60-py312hc28c600_0.conda
   hash:
-    md5: ebfd4475ea44943615e04be128d40079
-    sha256: 3e06b8710cab5329b8ed086fb69f10cc0ac9da7bfe9827df7d7318ea910ab8e2
+    md5: 8dadd187801120e52f78502a03d10a1e
+    sha256: 397cab5405babcef712a652676b675b3b69d208024f8609d379393a7ffeedfc7
   category: main
   optional: false
 - name: awscrt
@@ -8254,7 +8254,7 @@ package:
   category: main
   optional: false
 - name: debugpy
-  version: 1.8.20
+  version: 1.8.21
   manager: conda
   platform: linux-64
   dependencies:
@@ -8263,10 +8263,10 @@ package:
     libstdcxx: '>=14'
     python: ''
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py312h8285ef7_0.conda
   hash:
-    md5: ee1b48795ceb07311dd3e665dd4f5f33
-    sha256: f20121b67149ff80bf951ccae7442756586d8789204cd08ade59397b22bfd098
+    md5: e6778419a1851f6e15820558abddfa04
+    sha256: b8dbe25820064a099f315bbb8f45f5bac3fddb63e96af3cbf0c93a830733ef34
   category: main
   optional: false
 - name: debugpy
@@ -9577,13 +9577,11 @@ package:
     libgfortran5: '>=14.3.0'
     libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libstdcxx: '>=14'
-    mpich: '>=5.0,<6.0a0'
     netcdf-fortran: '>=4.6.2,<4.7.0a0'
-    parallelio: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-mpi_mpich_ha43e4ac_103.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-nompi_h0c1e4bb_3.conda
   hash:
-    md5: b4ed7c955c215d632bfb745304f84d04
-    sha256: df29582456e3091ab5d0e7b7b2f1fd221dc829b8ca5603b45bc5fcd19d737bc5
+    md5: acd2eee9535335dede2a9eed181251c5
+    sha256: 7c91329051080f64fe81fd7346600bc07feaa60c102abc842f2b9b3c7a1d35aa
   category: main
   optional: false
 - name: esmf
@@ -9597,13 +9595,11 @@ package:
     libgfortran5: '>=14.3.0'
     libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libstdcxx: '>=14'
-    mpich: '>=5.0,<6.0a0'
     netcdf-fortran: '>=4.6.2,<4.7.0a0'
-    parallelio: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/esmf-8.9.1-mpi_mpich_hb075c57_103.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/esmf-8.9.1-nompi_h8ba66ce_3.conda
   hash:
-    md5: a51b89da8bdb8581aad8aadc506348b2
-    sha256: 5ed69d1aca9028efa3b47d56d708ad286469aa8c935ccadfc2664649b98ff21e
+    md5: c8d13ca44f86b5986c72bc43e671f6bf
+    sha256: ac18906a66b8f983b0ba6d4ff29e52f871c25c66328cac3c2bc12ad2e335fc36
   category: main
   optional: false
 - name: esmf
@@ -9883,67 +9879,67 @@ package:
   category: main
   optional: false
 - name: fastapi-cli
-  version: 0.0.23
+  version: 0.0.24
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
     rich-toolkit: '>=0.14.8'
     tomli: '>=2.0.0'
-    typer: '>=0.15.1'
+    typer: '>=0.16'
     uvicorn-standard: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.24-pyhcf101f3_0.conda
   hash:
-    md5: 442ec6511754418c87a84bc1dc0c5384
-    sha256: cb60fc8c96dcd2a6335914d4d6d7d5f5549c9e1ff4533be28ba699e648babf37
+    md5: 517d72c5d62875c99fc0e6d4359a03f1
+    sha256: 0c13b515d4424587b97dd6ede9277a659a1f580608faf3ab43341bf95a270aca
   category: main
   optional: false
 - name: fastapi-cli
-  version: 0.0.23
+  version: 0.0.24
   manager: conda
   platform: linux-aarch64
   dependencies:
     python: ''
     rich-toolkit: '>=0.14.8'
     tomli: '>=2.0.0'
-    typer: '>=0.15.1'
+    typer: '>=0.16'
     uvicorn-standard: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.24-pyhcf101f3_0.conda
   hash:
-    md5: 442ec6511754418c87a84bc1dc0c5384
-    sha256: cb60fc8c96dcd2a6335914d4d6d7d5f5549c9e1ff4533be28ba699e648babf37
+    md5: 517d72c5d62875c99fc0e6d4359a03f1
+    sha256: 0c13b515d4424587b97dd6ede9277a659a1f580608faf3ab43341bf95a270aca
   category: main
   optional: false
 - name: fastapi-cli
-  version: 0.0.23
+  version: 0.0.24
   manager: conda
   platform: osx-64
   dependencies:
     python: ''
     rich-toolkit: '>=0.14.8'
     tomli: '>=2.0.0'
-    typer: '>=0.15.1'
+    typer: '>=0.16'
     uvicorn-standard: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.24-pyhcf101f3_0.conda
   hash:
-    md5: 442ec6511754418c87a84bc1dc0c5384
-    sha256: cb60fc8c96dcd2a6335914d4d6d7d5f5549c9e1ff4533be28ba699e648babf37
+    md5: 517d72c5d62875c99fc0e6d4359a03f1
+    sha256: 0c13b515d4424587b97dd6ede9277a659a1f580608faf3ab43341bf95a270aca
   category: main
   optional: false
 - name: fastapi-cli
-  version: 0.0.23
+  version: 0.0.24
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
     rich-toolkit: '>=0.14.8'
     tomli: '>=2.0.0'
-    typer: '>=0.15.1'
+    typer: '>=0.16'
     uvicorn-standard: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.24-pyhcf101f3_0.conda
   hash:
-    md5: 442ec6511754418c87a84bc1dc0c5384
-    sha256: cb60fc8c96dcd2a6335914d4d6d7d5f5549c9e1ff4533be28ba699e648babf37
+    md5: 517d72c5d62875c99fc0e6d4359a03f1
+    sha256: 0c13b515d4424587b97dd6ede9277a659a1f580608faf3ab43341bf95a270aca
   category: main
   optional: false
 - name: fastapi-core
@@ -10381,10 +10377,10 @@ package:
     x264: '>=1!164.3095,<1!165'
     x265: '>=3.5,<3.6.0a0'
     xorg-libx11: '>=1.8.13,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-8.1.1-gpl_h928bf72_102.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-8.1.1-gpl_hd45c978_902.conda
   hash:
-    md5: e2c81fadf37680e269edd538cb313d1e
-    sha256: 4fc58b8799dfbdce3cf760aae7d2f561b6e7898e886ad70b4dc5311a8a7e85c5
+    md5: 38b7f8ff64ef2a190d6f5db79419d93b
+    sha256: 4a611d7bd5b91d75b5ec25e976c6c1cb5ca301ed27876ace3e654e9c3f2eafbd
   category: main
   optional: false
 - name: ffmpeg
@@ -11145,7 +11141,7 @@ package:
   category: main
   optional: false
 - name: fontconfig
-  version: 2.18.0
+  version: 2.18.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -11156,14 +11152,14 @@ package:
     libgcc: '>=14'
     libuuid: '>=2.42.1,<3.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.0-h27c8c51_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
   hash:
-    md5: 06965b2f9854d0b15e0443ee81fe83dc
-    sha256: e798086d8a65d55dc4c51f5746705639c9a5f2eeb0b8fc50e6152cfc0d69a4e8
+    md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+    sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
   category: main
   optional: false
 - name: fontconfig
-  version: 2.18.0
+  version: 2.18.1
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -11173,14 +11169,14 @@ package:
     libgcc: '>=14'
     libuuid: '>=2.42.1,<3.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.0-hba86a56_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
   hash:
-    md5: b660d59a9d0fb3297327418624acaec3
-    sha256: 1805f4ab3d9e1734a5a17abccc2cb0fdade51d4d5f29bdc410600ea0115ec050
+    md5: f4d29a0cd77104a683607319a542ac7e
+    sha256: 2ccfd118269d363a5506161c4a0d96da46d2f01beecc74e0540a54b4737d0e45
   category: main
   optional: false
 - name: fontconfig
-  version: 2.18.0
+  version: 2.18.1
   manager: conda
   platform: osx-64
   dependencies:
@@ -11190,14 +11186,14 @@ package:
     libfreetype6: '>=2.14.3'
     libintl: '>=0.25.1,<1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.18.0-h7a4440b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.18.1-h7a4440b_0.conda
   hash:
-    md5: 0307bd7aa60a2f68e26bce6e54ed8956
-    sha256: 4495ee28d8c15c202a792ade053c9df8bfda81cdf50e78357edb536d6477c44f
+    md5: 17925ae2a399d859c0b978934df591e3
+    sha256: 134aed823beae85798607e32b78aa1368afbfbea145a43c974d88269f1013287
   category: main
   optional: false
 - name: fontconfig
-  version: 2.18.0
+  version: 2.18.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -11207,10 +11203,10 @@ package:
     libfreetype6: '>=2.14.3'
     libintl: '>=0.25.1,<1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.18.0-h2b252f5_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.18.1-h2b252f5_0.conda
   hash:
-    md5: cf31c25b5770548a394478bb6180ddbc
-    sha256: 938d18fca474d5a7ed716b88dbc4f962f9a44ac9f2fe29393d7d9d04ac6cbf15
+    md5: 9d928e6a62192141fb6540a3125b1345
+    sha256: 8607d8d0b32f9f6fc61ea8c06b537486b78428a04516658222fa4d1d521af765
   category: main
   optional: false
 - name: fonts-conda-ecosystem
@@ -13516,55 +13512,55 @@ package:
   category: main
   optional: false
 - name: google-cloud-sdk
-  version: 570.0.0
+  version: 571.0.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-570.0.0-py312h7900ff3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-571.0.0-py312h7900ff3_0.conda
   hash:
-    md5: c4663cdd2a4653c0a84f95a0227c9b8d
-    sha256: 9b00e1ac3dfd5a60c6d15c90f6f367e2a96d788c026358bdddae0ece489c3dcc
+    md5: dedf2ef75d0f01c92e73df4bfccb0a3c
+    sha256: 8c6beb9954409803f00fdbf31297645e85cae56136ca68d25d184a85be451fe8
   category: main
   optional: false
 - name: google-cloud-sdk
-  version: 570.0.0
+  version: 571.0.0
   manager: conda
   platform: linux-aarch64
   dependencies:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/google-cloud-sdk-570.0.0-py312h996f985_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/google-cloud-sdk-571.0.0-py312h996f985_0.conda
   hash:
-    md5: 06ff8b97da474d3b24c41cd654ea8677
-    sha256: c2ec58c48687d34298bf3deba488779c56a2bc5aeaaf48d9dfc0d17ae690da1d
+    md5: a5fe89f1a5507e06fbde509b0fee2482
+    sha256: 6de5caa877992a86878654a4497bff32c104bfb6fc9b2f0b995f0ae5d088132a
   category: main
   optional: false
 - name: google-cloud-sdk
-  version: 570.0.0
+  version: 571.0.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/google-cloud-sdk-570.0.0-py312hb401068_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/google-cloud-sdk-571.0.0-py312hb401068_0.conda
   hash:
-    md5: e3830fbb4195ef9eb73118786b72135a
-    sha256: b34f5a88f088e7ebf86a8b45ef86bda90dc2d24ca51ded6e01e704b1d5b647a6
+    md5: d69a7d10ebb8f9d28b4355b374955654
+    sha256: d72382942ba65e44ca035044b0616612804c46f7a3b21f6103c782264f9e4d14
   category: main
   optional: false
 - name: google-cloud-sdk
-  version: 570.0.0
+  version: 571.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/google-cloud-sdk-570.0.0-py312h81bd7bf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/google-cloud-sdk-571.0.0-py312h81bd7bf_0.conda
   hash:
-    md5: bbc33c39cfa09c5cabcfa6b3d5c8f7cd
-    sha256: b3f20945d5611c5824b2cbb4afed069008f6f25e4b34d46a352292ec80c3d918
+    md5: cd70a9f987c87cf715d1c6dcd408d124
+    sha256: 7df0815d5830d2d2b1f30a12c42cf053cbb6646f42f60fbf7e639990f7fac7f7
   category: main
   optional: false
 - name: google-cloud-storage
@@ -13937,56 +13933,56 @@ package:
   category: main
   optional: false
 - name: graphite2
-  version: 1.3.14
+  version: 1.3.15
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
   hash:
-    md5: 2cd94587f3a401ae05e03a6caf09539d
-    sha256: 25ba37da5c39697a77fce2c9a15e48cf0a84f1464ad2aafbe53d8357a9f6cc8c
+    md5: cf09e9fc938518e91d0706572cadf17a
+    sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
   category: main
   optional: false
 - name: graphite2
-  version: 1.3.14
+  version: 1.3.15
   manager: conda
   platform: linux-aarch64
   dependencies:
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-hfae3067_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
   hash:
-    md5: 4aa540e9541cc9d6581ab23ff2043f13
-    sha256: c9b1781fe329e0b77c5addd741e58600f50bef39321cae75eba72f2f381374b7
+    md5: 4db044857ab1d09b2e8f0013c65387c1
+    sha256: 3e529c517a76a1f4497c51eeedeeb927d33f732dcdb48055a020a83eb3e4e95c
   category: main
   optional: false
 - name: graphite2
-  version: 1.3.14
+  version: 1.3.15
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.14-h21dd04a_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.15-hcc62823_0.conda
   hash:
-    md5: ba63822087afc37e01bf44edcc2479f3
-    sha256: c356eb7a42775bd2bae243d9987436cd1a442be214b1580251bb7fdc136d804b
+    md5: 6a0525cf3166f16b9e156fb6b2cac5c0
+    sha256: aaebae3c0e713579e52de6fd4eec54a172e28c7f90d90da4583e91b1634a7fee
   category: main
   optional: false
 - name: graphite2
-  version: 1.3.14
+  version: 1.3.15
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.14-hec049ff_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.15-hf6b4638_0.conda
   hash:
-    md5: 0fc46fee39e88bbcf5835f71a9d9a209
-    sha256: c507ae9989dbea7024aa6feaebb16cbf271faac67ac3f0342ef1ab747c20475d
+    md5: 0d576cff278a2e60456d5b2c0a1ffda3
+    sha256: c0a060d7b7a05669043ef3f68c7a1025c8594e1ab73735afb64c35e8baa41da5
   category: main
   optional: false
 - name: graphviz
@@ -14974,7 +14970,7 @@ package:
   category: main
   optional: false
 - name: harfbuzz
-  version: 14.2.0
+  version: 14.2.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -14982,42 +14978,42 @@ package:
     cairo: '>=1.18.4,<2.0a0'
     graphite2: '>=1.3.14,<2.0a0'
     icu: '>=78.3,<79.0a0'
-    libexpat: '>=2.7.5,<3.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libglib: '>=2.86.4,<3.0a0'
+    libglib: '>=2.88.1,<3.0a0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
   hash:
-    md5: e194f6a2f498f0c7b1e6498bd0b12645
-    sha256: 232c95b56d16d33d8256026a3b1ad34f7f9a75c179d388854be0fd624ddba9e3
+    md5: 21ee4640b7c2d94e584349fa12b29b9a
+    sha256: da9901aa1e20cbc2369fda212039b294dd02bce95f005539bab840b7310bf7d0
   category: main
   optional: false
 - name: harfbuzz
-  version: 14.2.0
+  version: 14.2.1
   manager: conda
   platform: linux-aarch64
   dependencies:
     cairo: '>=1.18.4,<2.0a0'
     graphite2: '>=1.3.14,<2.0a0'
     icu: '>=78.3,<79.0a0'
-    libexpat: '>=2.7.5,<3.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libglib: '>=2.86.4,<3.0a0'
+    libglib: '>=2.88.1,<3.0a0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.0-h1134a53_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h1134a53_0.conda
   hash:
-    md5: 1775defbef30aa990498e753a948cb18
-    sha256: cb3e67e8045577b944b64534907d194ebc44e0959e0842847c18a4067eeeb9f6
+    md5: 5f3ec279ab7cc391b7dff69dc08298fa
+    sha256: 17a671aa62e1f0a8750514353e3d6e9aab80598908d9b107fc7f3cf7972176b6
   category: main
   optional: false
 - name: harfbuzz
-  version: 14.2.0
+  version: 14.2.1
   manager: conda
   platform: osx-64
   dependencies:
@@ -15026,19 +15022,19 @@ package:
     graphite2: '>=1.3.14,<2.0a0'
     icu: '>=78.3,<79.0a0'
     libcxx: '>=19'
-    libexpat: '>=2.7.5,<3.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
-    libglib: '>=2.86.4,<3.0a0'
+    libglib: '>=2.88.1,<3.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-14.2.0-hf0bc557_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-14.2.1-hf0bc557_0.conda
   hash:
-    md5: e7fd9056aa65f6dac6558b39c332c907
-    sha256: ab070b8961569fbdd3e414bee89887f1ca97522c73afb0fa2f055ad775c7dd20
+    md5: d217d80acf915fd7af2bb416a7d57e5a
+    sha256: d329b82aab0681aada77dfcb709fb42ab59403339eb886df2b58695aeb7c6869
   category: main
   optional: false
 - name: harfbuzz
-  version: 14.2.0
+  version: 14.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -15047,15 +15043,15 @@ package:
     graphite2: '>=1.3.14,<2.0a0'
     icu: '>=78.3,<79.0a0'
     libcxx: '>=19'
-    libexpat: '>=2.7.5,<3.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
-    libglib: '>=2.86.4,<3.0a0'
+    libglib: '>=2.88.1,<3.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.0-h3103d1b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
   hash:
-    md5: ea75b03886981362d93bb4708ee14811
-    sha256: 40ccd6a589c60a4cedb2f9921dfa60ea5845b5ce323477b042b6f90218b239f6
+    md5: 389b1c7cb4738fa74f8a142336807a13
+    sha256: 5593f4aad6580707eb268e8dbb4c562a736d87bea03f5e1551becaebfe1a6620
   category: main
   optional: false
 - name: hdf4
@@ -15135,12 +15131,11 @@ package:
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
     openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-mpi_mpich_h1a5cfed_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda
   hash:
-    md5: 847f1a715e324125f8e67cffeb9a7887
-    sha256: 1ac07a4d7404fd6255b6aefee3f98b98e2263c22214555342ec0715dc134e428
+    md5: 0d0595612fa229dddb5fc565c260a11f
+    sha256: beb8a2fb18924ca7b5b82cfb50f008f882f577daef2c00ed88022abea35fec76
   category: main
   optional: false
 - name: hdf5
@@ -15161,12 +15156,11 @@ package:
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
     openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-2.1.0-mpi_mpich_h37d1499_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h6ea7a3c_105.conda
   hash:
-    md5: 7d08a65e504b3570ec6fc9ea7861ffbf
-    sha256: 83982d2ff55c50a9ddce3af667a79fdc9b28744a0bf50a9d9da06e4ed84de7ca
+    md5: 076103ea89b838e3e20b96985be64e88
+    sha256: 3f58ef9b51335d6f4a57d851de1c017eda4c12f3857b3f7722aeba6a6d30f9c8
   category: main
   optional: false
 - name: hdf5
@@ -20804,7 +20798,6 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    __cuda: ''
     aws-crt-cpp: '>=0.38.3,<0.38.4.0a0'
     aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
     azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
@@ -20827,10 +20820,10 @@ package:
     orc: '>=2.3.0,<2.3.1.0a0'
     snappy: '>=1.2.2,<1.3.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-23.0.1-h2634454_11_cuda.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-23.0.1-h23c15a8_11_cpu.conda
   hash:
-    md5: 2b1bc96d0455b5eb189a3c7d93f1309f
-    sha256: d3df31d651020eaeda0fd16e745e1e39d6f1eb7187861fa1572fb7973aff97cd
+    md5: 6acffc258353d9a94fe8be3b2e8d5c18
+    sha256: a8aad10d74d7d9dd723e53644d9510fa2c6ddc2c6eacd6651cbc7c205bb52f6a
   category: main
   optional: false
 - name: libarrow
@@ -20924,10 +20917,10 @@ package:
     libarrow-compute: 23.0.1
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-acero-23.0.1-hb326ee9_11_cuda.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-acero-23.0.1-hb326ee9_11_cpu.conda
   hash:
-    md5: fdc87a78fe4de3f7eeda7da8c4d5b306
-    sha256: 7a26c0ab12bf3879c90c757f3f8e50bfee6580b6a178daa117aec1f89fd2cad6
+    md5: 5117a4d91539ec4b239d28260b47dc4d
+    sha256: 231c5bb683ba8ef9a580fb119f4fb1f2b089529c23ab0bb338c6a869aee57d18
   category: main
   optional: false
 - name: libarrow-acero
@@ -20995,10 +20988,10 @@ package:
     libstdcxx: '>=14'
     libutf8proc: '>=2.11.3,<2.12.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-compute-23.0.1-hdd99842_11_cuda.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-compute-23.0.1-hdd99842_11_cpu.conda
   hash:
-    md5: 86938fb4d178fa3e47bfac14145ebfa5
-    sha256: 86600db2d8d54938df5bff9db410062528aeaf0ddb68b57f31e1ecfd61b1b2a0
+    md5: 754d51aa8b553b946ce0a71a2f661c25
+    sha256: 4b2b1908d86ea100edecad59fc05cefaa17a47d13d89d0d8d49368c91e3e9520
   category: main
   optional: false
 - name: libarrow-compute
@@ -21070,10 +21063,10 @@ package:
     libgcc: '>=14'
     libparquet: 23.0.1
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-dataset-23.0.1-hb326ee9_11_cuda.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-dataset-23.0.1-hb326ee9_11_cpu.conda
   hash:
-    md5: c28e60be66fd26de2103ac689b9f402f
-    sha256: 2de9ddd56824c6efa02303cafd4dfd97b0f9e60f84e068895ee8db0f7e928a24
+    md5: 83db55485b671aaacb5cb7f1d56ab424
+    sha256: f085407bbd2675766eff14652347827c69262cc3cb3ffd627a9c0bb8f2db5e37
   category: main
   optional: false
 - name: libarrow-dataset
@@ -21147,10 +21140,10 @@ package:
     libgcc: '>=14'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-substrait-23.0.1-hf29bd21_11_cuda.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-substrait-23.0.1-hf29bd21_11_cpu.conda
   hash:
-    md5: 4c691c741d516615389e8cf2c6002366
-    sha256: bff2c4d54178e28f44944f21dac3bd5dcd3e4b115366dd9d8d73bb4df4fea6be
+    md5: 1966b213a0820e9156b33b052d938b3d
+    sha256: b099826e77aee8c5c2bfa1c6dbc4a6852cfc806f2827a75f4055214df095b002
   category: main
   optional: false
 - name: libarrow-substrait
@@ -21816,27 +21809,27 @@ package:
   category: main
   optional: false
 - name: libcxx
-  version: 22.1.6
+  version: 22.1.7
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.6-h19cb2f5_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.7-h19cb2f5_0.conda
   hash:
-    md5: fa1bbb55bfda7a8a022d508fb03f1625
-    sha256: 6d60efb63fe4d0299526fcb26e06de1933de55c36fc2ae5a1478f1aa734604bb
+    md5: 423373b842c3861da6cfa8c8915798ce
+    sha256: c03c298355dea54b729ed6c5f1e6dbd0e2426906039eba8aa2ba1254d005b7d8
   category: main
   optional: false
 - name: libcxx
-  version: 22.1.6
+  version: 22.1.7
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.6-h55c6f16_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.7-h55c6f16_0.conda
   hash:
-    md5: 589cc6f6222fdc0eaf8e90bc38fcce7b
-    sha256: 3e2f8ad32ddab88c5114b9aa2160f8c129f515df0e551d0d86ef5744446afdbd
+    md5: 0325fbe13eb6dd39234eb305ac1b3cb8
+    sha256: cceb668dc1b71f054b1036dd83eca2e02c0c3a4b2ba3ad28c74a982d819597a3
   category: main
   optional: false
 - name: libdeflate
@@ -22275,60 +22268,6 @@ package:
   hash:
     md5: ef22e9ab1dc7c2f334252f565f90b3b8
     sha256: 3133fb6bfa871288b92c8b8752696686a841bf4ffe035aa3038033c9e15b738e
-  category: main
-  optional: false
-- name: libfabric
-  version: 2.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libfabric1: 2.5.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.1-ha770c72_1.conda
-  hash:
-    md5: 0b82ff1ab3db9122f20cafe93f61bc3b
-    sha256: c2b53beed03c735b18116d5227410b15cc9fbef209795212afd179f8c8a5fd70
-  category: main
-  optional: false
-- name: libfabric
-  version: 2.5.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libfabric1: 2.5.1
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libfabric-2.5.1-h8af1aa0_1.conda
-  hash:
-    md5: 192389236af398fec30a73cd2f6e441a
-    sha256: b4a9429a4dba4029543ae999b3a72625b07f6c10c9b096ad3cdeee206ac83657
-  category: main
-  optional: false
-- name: libfabric1
-  version: 2.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    libgcc: '>=14'
-    libnl: '>=3.11.0,<4.0a0'
-    rdma-core: '>=63.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.1-h6b3ec72_1.conda
-  hash:
-    md5: 4a7168d686b6125ba546134dddb16721
-    sha256: f64b69e48636871081fde0604ed37fac32a7146073ad2899550bcc0b14e7c09d
-  category: main
-  optional: false
-- name: libfabric1
-  version: 2.5.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    libgcc: '>=14'
-    libnl: '>=3.11.0,<4.0a0'
-    rdma-core: '>=63.0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libfabric1-2.5.1-h6b50f16_1.conda
-  hash:
-    md5: 447a66768c019e33a2c38ee4de92a101
-    sha256: 8106cca3dd8a0a16cfcb2855e092c651ec5bca6989fcad2c4962640a16ad7c70
   category: main
   optional: false
 - name: libffi
@@ -24419,19 +24358,17 @@ package:
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.19.0,<9.0a0'
     libgcc: '>=14'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
     libstdcxx: '>=14'
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libzip: '>=1.11.2,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
     openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-mpi_mpich_h65e3e28_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_h3c9b436_104.conda
   hash:
-    md5: 5954d774093fd57ba35ad04265c22a9e
-    sha256: 02f09c75003e2bd6077821e331ec1e7c85789a99ddee0ccf7f9108add2244d7f
+    md5: 6d38346d49e4638ec98649121d295d54
+    sha256: 6a1dbee34abe246c32abb89bd35855c25551de09562a719da97c4e5975f5f035
   category: main
   optional: false
 - name: libnetcdf
@@ -24446,19 +24383,17 @@ package:
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.19.0,<9.0a0'
     libgcc: '>=14'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
     libstdcxx: '>=14'
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libzip: '>=1.11.2,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
     openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnetcdf-4.10.0-mpi_mpich_h9c907d1_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnetcdf-4.10.0-nompi_h441b98c_104.conda
   hash:
-    md5: 1ec225ddf0c9adab9e2d3d83a792f79e
-    sha256: 276648722f603e91266be2c17662846a336960010f2b62a4ee127d621db89575
+    md5: a6690e6628694b3a972ca973244180d9
+    sha256: 88002596e0e26d387c7091bce8672cfd87a1dec695b600e0ef55789f7ad8618a
   category: main
   optional: false
 - name: libnetcdf
@@ -24578,31 +24513,6 @@ package:
   hash:
     md5: 6ea18834adbc3b33df9bd9fb45eaf95b
     sha256: 2bc7bc3978066f2c274ebcbf711850cc9ab92e023e433b9631958a098d11e10a
-  category: main
-  optional: false
-- name: libnl
-  version: 3.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
-  hash:
-    md5: db63358239cbe1ff86242406d440e44a
-    sha256: ba7c5d294e3d80f08ac5a39564217702d1a752e352e486210faff794ac5001b4
-  category: main
-  optional: false
-- name: libnl
-  version: 3.11.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnl-3.11.0-h86ecc28_0.conda
-  hash:
-    md5: bb24d3dd7d028b70f0bb5f6d6e1329c0
-    sha256: 2e603bf640738511faf80de284daa031f0e67de66b77bed7d0da1045ef062abf
   category: main
   optional: false
 - name: libnsl
@@ -25678,10 +25588,10 @@ package:
     libstdcxx: '>=14'
     libthrift: '>=0.22.0,<0.22.1.0a0'
     openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-23.0.1-h87079af_11_cuda.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-23.0.1-h87079af_11_cpu.conda
   hash:
-    md5: 096016ceeb499e18497ccfc6d80e7f53
-    sha256: d3cbe89f2a841a792031fbfdc0667d6f31e420c89c922472fb26ea7a13728811
+    md5: e4d780551318fa517153151432595040
+    sha256: 245d18996e3b3171e1264e9ee5a425a6ee82a9d18b9003959b7b4feab6f11cda
   category: main
   optional: false
 - name: libparquet
@@ -25814,39 +25724,6 @@ package:
   hash:
     md5: 7402fdef0c155dcd18c0ff4c5853c4b2
     sha256: e9b39572e2feaef496167ba9f4ab75ed3afa4c16c3aeb0bb8c71adc515a74536
-  category: main
-  optional: false
-- name: libpnetcdf
-  version: 1.14.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libstdcxx: '>=14'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpnetcdf-1.14.1-mpi_mpich_h0009a5c_101.conda
-  hash:
-    md5: 2ec7034ce2c75d98ba3f73af3fecff08
-    sha256: 37bb953c0f6edeca52545dd4e43833348c3953be42d9c78315b4b0b627586c11
-  category: main
-  optional: false
-- name: libpnetcdf
-  version: 1.14.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libstdcxx: '>=14'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpnetcdf-1.14.1-mpi_mpich_h475dd2c_101.conda
-  hash:
-    md5: 128abe992c2c20bb6394e45b5dbb4515
-    sha256: d9988e5934480100b1031c335e07c7df5d2b3427ac0619243fe17caca15b30be
   category: main
   optional: false
 - name: libpng
@@ -26021,13 +25898,13 @@ package:
   category: main
   optional: false
 - name: librsvg
-  version: 2.62.2
+  version: 2.62.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     cairo: '>=1.18.4,<2.0a0'
-    fontconfig: '>=2.17.1,<3.0a0'
+    fontconfig: '>=2.18.0,<3.0a0'
     fonts-conda-ecosystem: ''
     gdk-pixbuf: '>=2.44.6,<3.0a0'
     harfbuzz: '>=14.2.0'
@@ -26035,19 +25912,19 @@ package:
     libglib: '>=2.88.1,<3.0a0'
     libxml2-16: '>=2.14.6'
     pango: '>=1.56.4,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.2-h4c96295_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
   hash:
-    md5: e318357f3d948cc16936d9f3b36cc7d9
-    sha256: 864d93b0385778c7495c369d9df408e2b436ef136c8f7de645e25fd461acc553
+    md5: 492c8d9b1c564c2e948b6cb4ba0f8261
+    sha256: 5571bd8239d71961d4e3ce972f865b3ea95a91ce0b53d5749fe2dd24254ddbda
   category: main
   optional: false
 - name: librsvg
-  version: 2.62.2
+  version: 2.62.3
   manager: conda
   platform: linux-aarch64
   dependencies:
     cairo: '>=1.18.4,<2.0a0'
-    fontconfig: '>=2.17.1,<3.0a0'
+    fontconfig: '>=2.18.0,<3.0a0'
     fonts-conda-ecosystem: ''
     gdk-pixbuf: '>=2.44.6,<3.0a0'
     harfbuzz: '>=14.2.0'
@@ -26055,50 +25932,50 @@ package:
     libglib: '>=2.88.1,<3.0a0'
     libxml2-16: '>=2.14.6'
     pango: '>=1.56.4,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.62.2-hf685517_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.62.3-hf685517_0.conda
   hash:
-    md5: aa215afd17a243a4394f2297f83651e2
-    sha256: 427486a9eae80874223a3f24fdbf16123330f7a7d89cacee88b460123038d0de
+    md5: 38209cc04b3e3e5624c534bc703e6939
+    sha256: c95ac70755863d8522c1115b54afca86148ea25366b616aa84c993c2ca54b9ce
   category: main
   optional: false
 - name: librsvg
-  version: 2.62.2
+  version: 2.62.3
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
     cairo: '>=1.18.4,<2.0a0'
-    fontconfig: '>=2.17.1,<3.0a0'
+    fontconfig: '>=2.18.0,<3.0a0'
     fonts-conda-ecosystem: ''
     gdk-pixbuf: '>=2.44.6,<3.0a0'
     harfbuzz: '>=14.2.0'
     libglib: '>=2.88.1,<3.0a0'
     libxml2-16: '>=2.14.6'
     pango: '>=1.56.4,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/librsvg-2.62.2-h7321050_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/librsvg-2.62.3-h7321050_0.conda
   hash:
-    md5: 533bb36caff9ef37e59823562e97f925
-    sha256: 891a5c97cf7f1795f5e480c9f6c50f4758a77695c5e649809da69d98edc61f87
+    md5: 2d5f6b880486d5058c7eab0db04b1bc9
+    sha256: 4e6ceb25dcc7b67d550e2b6ce98da585b49dd4590f21a709dd6ec626df3b8c19
   category: main
   optional: false
 - name: librsvg
-  version: 2.62.2
+  version: 2.62.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     cairo: '>=1.18.4,<2.0a0'
-    fontconfig: '>=2.17.1,<3.0a0'
+    fontconfig: '>=2.18.0,<3.0a0'
     fonts-conda-ecosystem: ''
     gdk-pixbuf: '>=2.44.6,<3.0a0'
     harfbuzz: '>=14.2.0'
     libglib: '>=2.88.1,<3.0a0'
     libxml2-16: '>=2.14.6'
     pango: '>=1.56.4,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.62.2-he8aa2a2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.62.3-he8aa2a2_0.conda
   hash:
-    md5: 44d4dc506e384f90cad14e5de90fbe3d
-    sha256: 17c1544598dd50840e74ef17ea5b4fd27408140827f3f2c17c052086d4036a88
+    md5: 6973724fadafe66ac6e4f1c55c191407
+    sha256: f5b4fb7b6f13bbfca59613bff2e70b5a398e80727b9d0f814837ffcbc34185e1
   category: main
   optional: false
 - name: librttopo
@@ -27969,27 +27846,27 @@ package:
   category: main
   optional: false
 - name: llvm-openmp
-  version: 22.1.6
+  version: 22.1.7
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.6-h0d3cbff_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.7-h0d3cbff_0.conda
   hash:
-    md5: b67316dec3b5c028b6b1bb6fd713c14e
-    sha256: afbea63c0ffed8f150ba41a3e85bd849560f15f879d0f1b5e5fb6b90eca8ea78
+    md5: 301c1db2d75ac8a91f46d21652e08dd6
+    sha256: c8eeb6bca45680db8974b78e0524b2ab3c285a9916a0b3356329d1f949b1311b
   category: main
   optional: false
 - name: llvm-openmp
-  version: 22.1.6
+  version: 22.1.7
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.6-hc7d1edf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.7-hc7d1edf_0.conda
   hash:
-    md5: b8cf70b77b2ed10d5f82e367c327b76b
-    sha256: 12d3652549a9abd30f3cc14797715327b86e91001d11865106eb3e02c40be9da
+    md5: 7c6a5897a8bc5b6d509a4ee9dec7fcc8
+    sha256: 6bf27376f11198c01a88a1c8234470f45bce0aa7502b7e7988ef03ef5db3a890
   category: main
   optional: false
 - name: llvmlite
@@ -29461,69 +29338,6 @@ package:
     sha256: d65d5a00278544639ba4f99887154be00a1f57afb0b34d80b08e5cba40a17072
   category: main
   optional: false
-- name: mpi
-  version: 1.0.1
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-mpich.conda
-  hash:
-    md5: 1052de900d672ec8b3713b8e300a8f06
-    sha256: eacc189267202669a1c5c849dcca2298f41acb3918f05cf912d7d61ee7176fac
-  category: main
-  optional: false
-- name: mpi
-  version: 1.0.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-mpich.conda
-  hash:
-    md5: 1052de900d672ec8b3713b8e300a8f06
-    sha256: eacc189267202669a1c5c849dcca2298f41acb3918f05cf912d7d61ee7176fac
-  category: main
-  optional: false
-- name: mpich
-  version: 5.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libfabric: ''
-    libfabric1: '>=1.14.0'
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libhwloc: '>=2.13.0,<2.13.1.0a0'
-    libstdcxx: '>=14'
-    mpi: 1.0.*
-    ucx: '>=1.20.0,<1.21.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpich-5.0.1-h6f9170e_0.conda
-  hash:
-    md5: 47a868b6ab372a8623f2a612d5979940
-    sha256: 6ebda028cde067c9effa285660e9c3e81361a700ac3b13d6b400ef9c4fbaa316
-  category: main
-  optional: false
-- name: mpich
-  version: 5.0.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libfabric: ''
-    libfabric1: '>=1.14.0'
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libhwloc: '>=2.13.0,<2.13.1.0a0'
-    libstdcxx: '>=14'
-    mpi: 1.0.*
-    ucx: '>=1.20.0,<1.21.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mpich-5.0.1-hc4b3ac6_0.conda
-  hash:
-    md5: 315b6a87ea80f8253e385271c0ca4763
-    sha256: d366dbc16fd8cd41cfdb3a8ac68d477009c3ef344316d5c5b1d535b5ba3c3026
-  category: main
-  optional: false
 - name: mpmath
   version: 1.4.1
   manager: conda
@@ -30846,11 +30660,10 @@ package:
     libgfortran5: '>=14.3.0'
     libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-mpi_mpich_h67749c9_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-nompi_h4a60669_105.conda
   hash:
-    md5: fe8d6e0db37ccab85921a68868b9003b
-    sha256: 5226b4af7b4581e1fc0b02b93f7c2aeb68daa59a06dcf3271a4fc8c3b007e7ef
+    md5: 19c44fef9eba50f926770ee530742b10
+    sha256: 5df7a482cd3ed296fb56b3d4dca0755673f768e5fc244e27e44d5d8a9975e9ee
   category: main
   optional: false
 - name: netcdf-fortran
@@ -30864,11 +30677,10 @@ package:
     libgfortran5: '>=14.3.0'
     libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/netcdf-fortran-4.6.2-mpi_mpich_h879aca7_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/netcdf-fortran-4.6.2-nompi_hcd9d1cc_105.conda
   hash:
-    md5: ea6b294afc4d0809bd3fed8600f9514a
-    sha256: 800977afb5087a09683e742e41cc682e7bcf71446d92207e0fee3942e346d297
+    md5: 6fa8376a86744dcc6f0f060f04a6e8c5
+    sha256: ec5c25624c0b08a00680ee66bffd789a46c2b4efafb0d1bad49f8f288829467a
   category: main
   optional: false
 - name: netcdf-fortran
@@ -33203,41 +33015,6 @@ package:
   hash:
     md5: 4b433508ebb295c05dd3d03daf27f7bb
     sha256: b57c59cf5abb06d407b3a79017b990ca5bfb10c15a10c62fc29e113f2b12d9a9
-  category: main
-  optional: false
-- name: parallelio
-  version: 2.6.9
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libnetcdf: '>=4.10.0,<4.10.1.0a0'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/parallelio-2.6.9-mpi_mpich_h462fbca_102.conda
-  hash:
-    md5: 61f401bc21aba557adbc3614b39bfa92
-    sha256: 31d3f1efeaa55109c287f3930ca3627e377f699ad2571d714cbadd8784f8b7af
-  category: main
-  optional: false
-- name: parallelio
-  version: 2.6.9
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libnetcdf: '>=4.10.0,<4.10.1.0a0'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/parallelio-2.6.9-mpi_mpich_hb506b6b_102.conda
-  hash:
-    md5: 2ac97e68ed8417beb45993cc37db77c6
-    sha256: 585f0286e787ec659fac9742cb47a2f9254e88ad014f2350b29fcbf0e9118a59
   category: main
   optional: false
 - name: param
@@ -35668,10 +35445,10 @@ package:
     libzlib: '>=1.3.1,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-core-23.0.1-py312h4181037_0_cuda.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-core-23.0.1-py312h751d940_0_cpu.conda
   hash:
-    md5: ca945e417eefe1323f8e146bc660e35f
-    sha256: 06037f3ab440ccbaae718c2ca7356ee636d3737cff1f5eb11569992a4f36b834
+    md5: e7f8770a810245fa31ac55767008de52
+    sha256: 08a99f3aec73e809671060f29e3aad8781c3c175a6b10e2a8b6d817b1193544a
   category: main
   optional: false
 - name: pyarrow-core
@@ -39400,39 +39177,6 @@ package:
     sha256: 4e2c1702c7c1dc4f8020585335c3ded9b4ed7861bf02ad7d4fa5532335cfe7d3
   category: main
   optional: false
-- name: rdma-core
-  version: '63.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libnl: '>=3.11.0,<4.0a0'
-    libstdcxx: '>=14'
-    libsystemd0: '>=257.13'
-    libudev1: '>=257.13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.0-h192683f_1.conda
-  hash:
-    md5: da47d3251c0f0d16b2801afe5a77b532
-    sha256: f0931894c751b22be09d7c976343a2957a14a59cfe0db04d916d1b93bd66ffcf
-  category: main
-  optional: false
-- name: rdma-core
-  version: '63.0'
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libnl: '>=3.11.0,<4.0a0'
-    libstdcxx: '>=14'
-    libsystemd0: '>=257.13'
-    libudev1: '>=257.13'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-63.0-h1f0f388_1.conda
-  hash:
-    md5: 94e99208cc8828d5953fac098814a0e9
-    sha256: 89dc4066bf0a2ee8e0cdeb6b6e8884c2c36c9a82855a438a0720ee59297fae3e
-  category: main
-  optional: false
 - name: re2
   version: 2025.11.05
   manager: conda
@@ -40885,84 +40629,88 @@ package:
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.8.0
+  version: 1.9.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-    joblib: '>=1.3.0'
+    joblib: '>=1.4.0'
     libgcc: '>=14'
     libstdcxx: '>=14'
+    narwhals: '>=2.0.1'
     numpy: '>=1.23,<3'
     python: ''
     python_abi: 3.12.*
     scipy: '>=1.10.0'
-    threadpoolctl: '>=3.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py312h3226591_1.conda
+    threadpoolctl: '>=3.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py312h3226591_0.conda
   hash:
-    md5: 38decbeae260892040709cafc0514162
-    sha256: 23c643c37fafa14ba3f2b7a407126ea5e732a3655ea8157cf9f977098f863448
+    md5: e6e9b5795bb495325c3b4ebd451519aa
+    sha256: 8c0cd0326b5a17ddcf189fc4f119bf6871b7853595c088075847c484a3ed567e
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.8.0
+  version: 1.9.0
   manager: conda
   platform: linux-aarch64
   dependencies:
     _openmp_mutex: '>=4.5'
-    joblib: '>=1.3.0'
+    joblib: '>=1.4.0'
     libgcc: '>=14'
     libstdcxx: '>=14'
+    narwhals: '>=2.0.1'
     numpy: '>=1.23,<3'
     python: 3.12.*
     python_abi: 3.12.*
     scipy: '>=1.10.0'
-    threadpoolctl: '>=3.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/scikit-learn-1.8.0-np2py312hca49013_1.conda
+    threadpoolctl: '>=3.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/scikit-learn-1.9.0-np2py312hca49013_0.conda
   hash:
-    md5: 4ee0a99cdf60dad5d9349985e14ee737
-    sha256: 6cdf1363ea485c6f7fc14c302bcea347308b4343200bda94d7a38b0dbb8c0e87
+    md5: 534988ee816470b09273e8c83b2950e5
+    sha256: 83c12ba5973b1c0963904adc329709055b26e8137c040d423ed5dfd8c4382f6c
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.8.0
+  version: 1.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    joblib: '>=1.3.0'
+    __osx: '>=11.0'
+    joblib: '>=1.4.0'
     libcxx: '>=19'
     llvm-openmp: '>=19.1.7'
+    narwhals: '>=2.0.1'
     numpy: '>=1.23,<3'
     python: ''
     python_abi: 3.12.*
     scipy: '>=1.10.0'
-    threadpoolctl: '>=3.2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.8.0-np2py312h47bbdc5_1.conda
+    threadpoolctl: '>=3.5.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.9.0-np2py312h691318a_0.conda
   hash:
-    md5: 9c037f2050f55c721704013b87c9724e
-    sha256: 1a03f549462e9c700c93664c663c08a651f6c93c0979384417ac132549c44b98
+    md5: 1c8b1c621007743653c544b9ec69d8bd
+    sha256: 10f41e90b84e1f998d2d752ecf8e6223f11fa56e86f8104692229f961f24240c
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.8.0
+  version: 1.9.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    joblib: '>=1.3.0'
+    joblib: '>=1.4.0'
     libcxx: '>=19'
     llvm-openmp: '>=19.1.7'
+    narwhals: '>=2.0.1'
     numpy: '>=1.23,<3'
     python: 3.12.*
     python_abi: 3.12.*
     scipy: '>=1.10.0'
-    threadpoolctl: '>=3.2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.8.0-np2py312he5ca3e3_1.conda
+    threadpoolctl: '>=3.5.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py312he5ca3e3_0.conda
   hash:
-    md5: ed7887c51edfa304c69a424279cec675
-    sha256: 5f640a06e001666f9d4dca7cca992f1753e722e9f6e50899d7d250c02ddf7398
+    md5: b2b777cdad320a08da92bb1f58040bfd
+    sha256: e140dce2c42d0a121a113e29fbde4fd95a69cdf528ea195558ba25b809b439b7
   category: main
   optional: false
 - name: scipy
@@ -43671,51 +43419,51 @@ package:
   category: main
   optional: false
 - name: traitlets
-  version: 5.15.0
+  version: 5.15.1
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
-    md5: 4bada6a6d908a27262af8ebddf4f7492
-    sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
+    md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+    sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
   category: main
   optional: false
 - name: traitlets
-  version: 5.15.0
+  version: 5.15.1
   manager: conda
   platform: linux-aarch64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
-    md5: 4bada6a6d908a27262af8ebddf4f7492
-    sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
+    md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+    sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
   category: main
   optional: false
 - name: traitlets
-  version: 5.15.0
+  version: 5.15.1
   manager: conda
   platform: osx-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
-    md5: 4bada6a6d908a27262af8ebddf4f7492
-    sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
+    md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+    sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
   category: main
   optional: false
 - name: traitlets
-  version: 5.15.0
+  version: 5.15.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
-    md5: 4bada6a6d908a27262af8ebddf4f7492
-    sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
+    md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+    sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
   category: main
   optional: false
 - name: traittypes
@@ -43849,55 +43597,55 @@ package:
   category: main
   optional: false
 - name: trollsift
-  version: 1.0.0
+  version: 1.0.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c9e0f517471f71f4a5ebac45ae3bbfa2
-    sha256: aa76ba7c535a4bcc297c9454bb9aeb873c1f8ad3b1e4c246908670ba7fd475c7
+    md5: f811b6bf76aba2311c448d5cedaaf080
+    sha256: 99a9f09f73df6bf374c240fc243acb0af3987f9d0725e5ed44215429e712f5b3
   category: main
   optional: false
 - name: trollsift
-  version: 1.0.0
+  version: 1.0.1
   manager: conda
   platform: linux-aarch64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c9e0f517471f71f4a5ebac45ae3bbfa2
-    sha256: aa76ba7c535a4bcc297c9454bb9aeb873c1f8ad3b1e4c246908670ba7fd475c7
+    md5: f811b6bf76aba2311c448d5cedaaf080
+    sha256: 99a9f09f73df6bf374c240fc243acb0af3987f9d0725e5ed44215429e712f5b3
   category: main
   optional: false
 - name: trollsift
-  version: 1.0.0
+  version: 1.0.1
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c9e0f517471f71f4a5ebac45ae3bbfa2
-    sha256: aa76ba7c535a4bcc297c9454bb9aeb873c1f8ad3b1e4c246908670ba7fd475c7
+    md5: f811b6bf76aba2311c448d5cedaaf080
+    sha256: 99a9f09f73df6bf374c240fc243acb0af3987f9d0725e5ed44215429e712f5b3
   category: main
   optional: false
 - name: trollsift
-  version: 1.0.0
+  version: 1.0.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c9e0f517471f71f4a5ebac45ae3bbfa2
-    sha256: aa76ba7c535a4bcc297c9454bb9aeb873c1f8ad3b1e4c246908670ba7fd475c7
+    md5: f811b6bf76aba2311c448d5cedaaf080
+    sha256: 99a9f09f73df6bf374c240fc243acb0af3987f9d0725e5ed44215429e712f5b3
   category: main
   optional: false
 - name: typer
-  version: 0.26.5
+  version: 0.26.7
   manager: conda
   platform: linux-64
   dependencies:
@@ -43906,14 +43654,14 @@ package:
     python: ''
     rich: '>=13.8.0'
     shellingham: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
   hash:
-    md5: af2517b95781c326d315514ff1460453
-    sha256: 9ae0a38b5ccf9e2cb07f7fa4f7a5b070e4e0680831abf391b7fd1be296273319
+    md5: 71d2c80673511fab927bd15592994030
+    sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
   category: main
   optional: false
 - name: typer
-  version: 0.26.5
+  version: 0.26.7
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -43922,14 +43670,14 @@ package:
     python: ''
     rich: '>=13.8.0'
     shellingham: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
   hash:
-    md5: af2517b95781c326d315514ff1460453
-    sha256: 9ae0a38b5ccf9e2cb07f7fa4f7a5b070e4e0680831abf391b7fd1be296273319
+    md5: 71d2c80673511fab927bd15592994030
+    sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
   category: main
   optional: false
 - name: typer
-  version: 0.26.5
+  version: 0.26.7
   manager: conda
   platform: osx-64
   dependencies:
@@ -43938,14 +43686,14 @@ package:
     python: ''
     rich: '>=13.8.0'
     shellingham: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
   hash:
-    md5: af2517b95781c326d315514ff1460453
-    sha256: 9ae0a38b5ccf9e2cb07f7fa4f7a5b070e4e0680831abf391b7fd1be296273319
+    md5: 71d2c80673511fab927bd15592994030
+    sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
   category: main
   optional: false
 - name: typer
-  version: 0.26.5
+  version: 0.26.7
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -43954,10 +43702,10 @@ package:
     python: ''
     rich: '>=13.8.0'
     shellingham: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
   hash:
-    md5: af2517b95781c326d315514ff1460453
-    sha256: 9ae0a38b5ccf9e2cb07f7fa4f7a5b070e4e0680831abf391b7fd1be296273319
+    md5: 71d2c80673511fab927bd15592994030
+    sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
   category: main
   optional: false
 - name: typing-extensions
@@ -44246,37 +43994,6 @@ package:
   hash:
     md5: 4fdd327852ffefc83173a7c029690d0c
     sha256: 9e5a0e70e876fca50de075b1cc6641cdc009a16c18f4d52ab03edb777729a1bc
-  category: main
-  optional: false
-- name: ucx
-  version: 1.20.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    rdma-core: '>=61.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.20.1-hbe80e26_0.conda
-  hash:
-    md5: 7d06bc10996e75c90b8cd7631b5dcf6c
-    sha256: 8f0ac4a92e4674eb4c87cdfc59d2fc7c2d0d1696689202eeb62ef715d82ce711
-  category: main
-  optional: false
-- name: ucx
-  version: 1.20.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    _openmp_mutex: '>=4.5'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    rdma-core: '>=61.0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ucx-1.20.1-hc4deba6_0.conda
-  hash:
-    md5: 3db915ee01a1bb59cfd1306e1210cf23
-    sha256: f1af140a36e3c971e3ddbfb907da79ab0c5eef9bc78ba4853f406bc9b61ee921
   category: main
   optional: false
 - name: ujson
@@ -45928,7 +45645,7 @@ package:
   category: main
   optional: false
 - name: xarray-spatial
-  version: 0.10.1
+  version: 0.10.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -45941,14 +45658,14 @@ package:
     urllib3: ''
     xarray: ''
     zstandard: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.2-pyhd8ed1ab_0.conda
   hash:
-    md5: bcbb516ee86e84254906cc1aeb4b0216
-    sha256: edf92d5609f2d5cc6ba510cc3584fdf55002c1f5c855b36bbd9a5e736a711163
+    md5: 235b842dd45d73f515394e640db614c5
+    sha256: df65d6a808619ca3b45aedeade36d6743a548db2979a64c5bf97734e7e9854ce
   category: main
   optional: false
 - name: xarray-spatial
-  version: 0.10.1
+  version: 0.10.2
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -45961,14 +45678,14 @@ package:
     urllib3: ''
     xarray: ''
     zstandard: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.2-pyhd8ed1ab_0.conda
   hash:
-    md5: bcbb516ee86e84254906cc1aeb4b0216
-    sha256: edf92d5609f2d5cc6ba510cc3584fdf55002c1f5c855b36bbd9a5e736a711163
+    md5: 235b842dd45d73f515394e640db614c5
+    sha256: df65d6a808619ca3b45aedeade36d6743a548db2979a64c5bf97734e7e9854ce
   category: main
   optional: false
 - name: xarray-spatial
-  version: 0.10.1
+  version: 0.10.2
   manager: conda
   platform: osx-64
   dependencies:
@@ -45981,14 +45698,14 @@ package:
     urllib3: ''
     xarray: ''
     zstandard: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.2-pyhd8ed1ab_0.conda
   hash:
-    md5: bcbb516ee86e84254906cc1aeb4b0216
-    sha256: edf92d5609f2d5cc6ba510cc3584fdf55002c1f5c855b36bbd9a5e736a711163
+    md5: 235b842dd45d73f515394e640db614c5
+    sha256: df65d6a808619ca3b45aedeade36d6743a548db2979a64c5bf97734e7e9854ce
   category: main
   optional: false
 - name: xarray-spatial
-  version: 0.10.1
+  version: 0.10.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -46001,10 +45718,10 @@ package:
     urllib3: ''
     xarray: ''
     zstandard: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.2-pyhd8ed1ab_0.conda
   hash:
-    md5: bcbb516ee86e84254906cc1aeb4b0216
-    sha256: edf92d5609f2d5cc6ba510cc3584fdf55002c1f5c855b36bbd9a5e736a711163
+    md5: 235b842dd45d73f515394e640db614c5
+    sha256: df65d6a808619ca3b45aedeade36d6743a548db2979a64c5bf97734e7e9854ce
   category: main
   optional: false
 - name: xarray_leaflet

--- a/pangeo-notebook/packages.txt
+++ b/pangeo-notebook/packages.txt
@@ -11,7 +11,7 @@ aiohttp==3.13.5
 aioitertools==0.13.0
 aiosignal==1.4.0
 alembic==1.18.4
-alsa-lib==1.2.15.3
+alsa-lib==1.2.16
 amqp==5.3.1
 annotated-doc==0.0.4
 annotated-types==0.7.0
@@ -51,7 +51,7 @@ aws-c-sdkutils==0.2.4
 aws-checksums==0.2.10
 aws-crt-cpp==0.38.3
 aws-sdk-cpp==1.11.747
-awscli==2.34.58
+awscli==2.34.60
 awscrt==0.32.2
 azure-core==1.41.0
 azure-core-cpp==1.16.2
@@ -135,7 +135,7 @@ dask-ml==2025.1.0
 datashader==0.19.1
 dav1d==1.2.1
 dbus==1.16.2
-debugpy==1.8.20
+debugpy==1.8.21
 decorator==5.3.1
 defusedxml==0.7.1
 deprecated==1.3.1
@@ -162,7 +162,7 @@ esmpy==8.9.1
 exceptiongroup==1.3.1
 executing==2.2.1
 fastapi==0.136.3
-fastapi-cli==0.0.23
+fastapi-cli==0.0.24
 fastapi-core==0.136.3
 fastar==0.11.0
 fastcore==1.13.2
@@ -182,7 +182,7 @@ font-ttf-dejavu-sans-mono==2.37
 font-ttf-inconsolata==3.000
 font-ttf-source-code-pro==2.038
 font-ttf-ubuntu==0.83
-fontconfig==2.18.0
+fontconfig==2.18.1
 fonts-conda-ecosystem==1
 fonts-conda-forge==1
 fonttools==4.63.0
@@ -222,14 +222,14 @@ google-api-core==2.30.3
 google-auth==2.53.0
 google-auth-oauthlib==1.4.0
 google-cloud-core==2.5.1
-google-cloud-sdk==570.0.0
+google-cloud-sdk==571.0.0
 google-cloud-storage==3.10.1
 google-cloud-storage-control==1.10.0
 google-crc32c==1.8.0
 google-resumable-media==2.8.0
 googleapis-common-protos==1.75.0
 googleapis-common-protos-grpc==1.75.0
-graphite2==1.3.14
+graphite2==1.3.15
 graphviz==14.1.2
 greenlet==3.5.1
 grpc-google-iam-v1==0.14.4
@@ -244,7 +244,7 @@ h3==4.3.0
 h3-py==4.3.0
 h5netcdf==1.8.1
 h5py==3.16.0
-harfbuzz==14.2.0
+harfbuzz==14.2.1
 hdf4==4.2.15
 hdf5==2.1.0
 heapdict==1.0.1
@@ -366,8 +366,6 @@ libegl-devel==1.7.0
 libev==4.33
 libevent==2.1.12
 libexpat==2.8.1
-libfabric==2.5.1
-libfabric1==2.5.1
 libffi==3.5.2
 libfido2==1.17.0
 libflac==1.5.0
@@ -407,7 +405,6 @@ liblapack==3.11.0
 liblzma==5.8.3
 libnetcdf==4.10.0
 libnghttp2==1.68.1
-libnl==3.11.0
 libnsl==2.0.1
 libogg==1.3.5
 libopenblas==0.3.33
@@ -431,11 +428,10 @@ libopus==1.6.1
 libparquet==23.0.1
 libpciaccess==0.19
 libplacebo==7.360.1
-libpnetcdf==1.14.1
 libpng==1.6.58
 libprotobuf==6.33.5
 libre2-11==2025.11.05
-librsvg==2.62.2
+librsvg==2.62.3
 librttopo==1.1.0
 libsecret==0.21.7
 libsndfile==1.2.2
@@ -498,8 +494,6 @@ minizip==4.2.1
 mistune==3.2.1
 morecantile==7.0.3
 mpg123==1.32.9
-mpi==1.0.1
-mpich==5.0.1
 mpmath==1.4.1
 msal==1.37.0
 msal_extensions==1.3.1
@@ -560,7 +554,6 @@ panel-material-ui==0.11.2
 pangeo-dask==2026.01.21
 pangeo-notebook==2026.01.21
 pango==1.56.4
-parallelio==2.6.9
 param==2.4.0
 parso==0.8.7
 partd==1.4.2
@@ -664,7 +657,6 @@ qhull==2020.2
 rasterio==1.5.0
 rav1e==0.8.1
 rclone==1.74.2
-rdma-core==63.0
 re2==2025.11.05
 readline==8.3
 rechunker==0.5.2
@@ -689,7 +681,7 @@ s3fs==2026.4.0
 s3transfer==0.17.1
 satpy==0.60.0
 scikit-image==0.26.0
-scikit-learn==1.8.0
+scikit-learn==1.9.0
 scipy==1.17.1
 sdl2==2.32.56
 sdl3==3.4.10
@@ -736,18 +728,17 @@ tomli==2.4.1
 toolz==1.1.0
 tornado==6.5.6
 tqdm==4.67.3
-traitlets==5.15.0
+traitlets==5.15.1
 traittypes==0.2.3
 trollimage==1.28.0
-trollsift==1.0.0
-typer==0.26.5
+trollsift==1.0.1
+typer==0.26.7
 typing-extensions==4.15.0
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 typing_utils==0.1.0
 tzdata==2025c
 uc-micro-py==2.0.0
-ucx==1.20.1
 ujson==5.12.1
 uncompresspy==0.4.1
 unicodedata2==17.0.1
@@ -779,7 +770,7 @@ wrapt==2.2.1
 x264==1%21164.3095
 x265==3.5
 xarray==2026.4.0
-xarray-spatial==0.10.1
+xarray-spatial==0.10.2
 xarray_leaflet==0.2.3
 xarrayutils==2.0.1
 xbatcher==0.4.0

--- a/pytorch-notebook/conda-linux-64.lock
+++ b/pytorch-notebook/conda-linux-64.lock
@@ -11,7 +11,6 @@ https://conda.anaconda.org/conda-forge/linux-64/gh-2.93.0-hfc2019e_0.conda#c4573
 https://conda.anaconda.org/conda-forge/linux-64/git-lfs-3.7.1-ha8f183a_1.conda#185f332b1a60ed24701358bb3c21aee2
 https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda#129e404c5b001f3ef5581316971e3ea0
 https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_0.conda#f8dcb0cff8f84f428bf76f1169bf50a7
-https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-mpich.conda#1052de900d672ec8b3713b8e300a8f06
 https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda#16c2a0e9c4a166e53632cfca4f68d020
 https://conda.anaconda.org/conda-forge/linux-64/onemkl-license-2026.0.0-hf2ce2f3_915.conda#f9a902d29c0980c672f77eff7be1794c
 https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda#f0599959a2447c1e544e216bddf393fa
@@ -25,7 +24,7 @@ https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-13.3.29-h376f
 https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda#a7970cd949a077b7cb9696379d338681
 https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda#eb83f3f8cecc3e9bff9e250817fc69b6
 https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda#d87ff7921124eccd67248aa483c23fec
-https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.6-h4922eb0_0.conda#a7f80a18bc21daad0f4d5c3fbad1e8c1
+https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.7-h4922eb0_0.conda#362702bd1f3c1b06ba5908ff18ef6d8c
 https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda#887b70e1d607fba7957aa02f9ee0d939
 https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2#fee5683a3f04bd15cbd8318b096a27ab
 https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda#75e9f795be506c96dd43cb09c7c8d557
@@ -34,7 +33,7 @@ https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda#c2a0
 https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda#4a13eeac0b5c8e5b8ab496e6c4ddd829
 https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda#18335a698559cdbcd86150a48bf54ba6
 https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda#57736f29cc2b0ec0b6c2952d3f101b6a
-https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda#dcdc58c15961dbf17a0621312b01f5cb
+https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda#18d273b22e96c97c2017813f099faa82
 https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda#e36ad70a7e0b48f091ed6902f04c23b8
 https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda#d2ffd7602c02f2b316fd921d39876885
 https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda#920bb03579f15389b9e512095ad995b7
@@ -96,7 +95,7 @@ https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda#f7d7
 https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda#4d4efd0645cd556fab54617c4ad477ef
 https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda#d411fc29e338efb48c5fd4576d71d881
 https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda#3bf7b9fd5a7136126e0234db4b87c8b6
-https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda#2cd94587f3a401ae05e03a6caf09539d
+https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda#cf09e9fc938518e91d0706572cadf17a
 https://conda.anaconda.org/conda-forge/linux-64/h3-4.4.1-h54a6638_0.conda#b8e023a9674dca4c703b5fa6218d22b8
 https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda#c80d8a3b84358cb967fa81e7075fbc8a
 https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda#10909406c1b0e4b57f9f4f0eb0999af8
@@ -233,7 +232,7 @@ https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.co
 https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda#4c2a8fef270f6c69591889b93f9f55c1
 https://conda.anaconda.org/conda-forge/noarch/dataclasses-0.8-pyhc8e2a94_3.tar.bz2#a362b2124b06aad102e2ee4581acee7d
 https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda#ce96f2f470d39bd96ce03945af92e280
-https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda#ee1b48795ceb07311dd3e665dd4f5f33
+https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py312h8285ef7_0.conda#e6778419a1851f6e15820558abddfa04
 https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda#61dcf784d59ef0bd62c57d982b154ace
 https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2#961b3a227b437d82ad7054484cfa71b2
 https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda#67999c5465064480fa8016d00ac768f6
@@ -247,7 +246,7 @@ https://conda.anaconda.org/conda-forge/linux-64/fastar-0.11.0-py312h42cbcb6_0.co
 https://conda.anaconda.org/conda-forge/noarch/fastcore-1.13.2-pyhcf101f3_0.conda#84fc5b6dc5de080478b3dd30c212ad6a
 https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda#8fa8358d022a3a9bd101384a808044c6
 https://conda.anaconda.org/conda-forge/noarch/findlibs-0.1.2-pyhd8ed1ab_0.conda#fa9e9ec7bf26619a8edd3e11155f15d6
-https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.0-h27c8c51_0.conda#06965b2f9854d0b15e0443ee81fe83dc
+https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda#e0e050cfa9fa85fe39632ab11cb7f3e0
 https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda#8462b5322567212beeb025f3519fb3e2
 https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.8.0-py312h447239a_0.conda#6a42923f35087cc88a9fac31ef096ce6
 https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda#2c11aa96ea85ced419de710c1c3a78ff
@@ -256,7 +255,7 @@ https://conda.anaconda.org/conda-forge/noarch/gast-0.7.0-pyhd8ed1ab_0.conda#377a
 https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda#7892f39a39ed39591a89a28eba03e987
 https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.1-pyhd8ed1ab_0.conda#43dd16b113cc7b244d923b630026ff4f
 https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.1-hee1de02_2.conda#e5a459d2bb98edb88de5a44bfad66b9d
-https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-570.0.0-py312h7900ff3_0.conda#c4663cdd2a4653c0a84f95a0227c9b8d
+https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-571.0.0-py312h7900ff3_0.conda#dedf2ef75d0f01c92e73df4bfccb0a3c
 https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py312h03f33d3_1.conda#68f704ea294dcec9e09edd9c3d233846
 https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.1-py312h8285ef7_0.conda#3a704672326e552b019390d832a4b095
 https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda#4d8df0b0db060d33c9a702ada998a8fe
@@ -285,7 +284,6 @@ https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.18.0.66-h85c024f_0.c
 https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda#49c553b47ff679a6a1e9fc80b9c5a2d4
 https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda#c3cc2864f82a944bc90a7beb4d3b0e88
 https://conda.anaconda.org/conda-forge/linux-64/libcusolver-12.2.2.18-h676940d_0.conda#6fe9b15c855e59034cb62fd86e4d3eea
-https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.1-h6b3ec72_1.conda#4a7168d686b6125ba546134dddb16721
 https://conda.anaconda.org/conda-forge/linux-64/libfido2-1.17.0-h8c08ba8_0.conda#f3a2fbd4644599669d5f274f98c04b30
 https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda#ec3c4350aa0261bf7f87b8ca15c8e80e
 https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-haa4a5bd_1023.conda#953b7cca897e21215302dbfe2af5cd0c
@@ -371,12 +369,11 @@ https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda#b53
 https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda#c07a6153f8306e45794774cf9b13bd32
 https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.6-py312h4c3975b_0.conda#dcbe46475eff6fb9d1adad473c984f39
 https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda#e5ce43272193b38c2e9037446c1d9206
-https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda#4bada6a6d908a27262af8ebddf4f7492
-https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.0-pyhd8ed1ab_0.conda#c9e0f517471f71f4a5ebac45ae3bbfa2
+https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda#37e3be7b6e2977d37b8fa5da229f5dc0
+https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.1-pyhd8ed1ab_0.conda#f811b6bf76aba2311c448d5cedaaf080
 https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda#0caa1af407ecff61170c9437a808404d
 https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda#f6d7aa696c67756a650e91e15e88223c
 https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-2.0.0-pyhcf101f3_0.conda#4fdd327852ffefc83173a7c029690d0c
-https://conda.anaconda.org/conda-forge/linux-64/ucx-1.20.1-hf72d326_0.conda#227baf40539ae6858afe99634faf883d
 https://conda.anaconda.org/conda-forge/linux-64/ujson-5.12.1-py312h8285ef7_1.conda#1a16c1e03a6d960a183086adabd4a52a
 https://conda.anaconda.org/conda-forge/noarch/uncompresspy-0.4.1-pyhd8ed1ab_0.conda#06de15bda7ff6019d8e02e6682664b63
 https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda#0b6c506ec1f272b685240e70a29261b8
@@ -447,7 +444,6 @@ https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.co
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda#fd312693df06da3578383232528c468d
 https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda#75932da6f03a6bef32b70a51e991f6eb
 https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.7-gpl_hc2c16d8_101.conda#bb1483d91797dae0b466cab86ceb59a7
-https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.1-ha770c72_1.conda#0b82ff1ab3db9122f20cafe93f61bc3b
 https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h5fbf134_12.conda#88c1c66987cd52a712eea89c27104be6
 https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda#f25206d7322c0e9648e8b83694d143ab
 https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda#16b6330783ce0d1ae8d22782173b32c9
@@ -545,7 +541,7 @@ https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.50-pyhd8ed1ab_0.cond
 https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda#fedbe80d864debab03541e1b447fc12a
 https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.78.1-py312h39ee1c6_0.conda#b1995dadc14463d8f914c54cf2061a07
 https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.28.3-h29cf534_0.conda#d14091382ba5e4b85ab11491ea85911c
-https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda#e194f6a2f498f0c7b1e6498bd0b12645
+https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda#21ee4640b7c2d94e584349fa12b29b9a
 https://conda.anaconda.org/conda-forge/noarch/hydra-core-1.3.2-pyhd8ed1ab_1.conda#a189dd36bcaaf4c7647deb2dcb4e1b05
 https://conda.anaconda.org/conda-forge/noarch/importlib-resources-7.1.0-pyhd8ed1ab_0.conda#e3bffa82b874f8b9a2631bddb3869529
 https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.0-pyh53cf698_0.conda#8e3caf9b45475eb00053f4bb60be0d15
@@ -561,7 +557,6 @@ https://conda.anaconda.org/conda-forge/linux-64/lxml-6.1.1-py312h63ddcf0_0.conda
 https://conda.anaconda.org/conda-forge/noarch/mako-1.3.12-pyhcf101f3_0.conda#a73036dabdd6dfe9679ed893baa8b230
 https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.2-pyhcf101f3_0.conda#ba0a9221ce1063f31692c07370d062f3
 https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda#ad6821df7a98510117db06e9a833281f
-https://conda.anaconda.org/conda-forge/linux-64/mpich-5.0.1-h6f9170e_0.conda#47a868b6ab372a8623f2a612d5979940
 https://conda.anaconda.org/conda-forge/noarch/obspec_utils-0.9.0-pyhd8ed1ab_0.conda#3289f38214d30fa6f32540d3fcb7c278
 https://conda.anaconda.org/conda-forge/linux-64/optree-0.19.1-py312hd9148b4_0.conda#5a9273e06750ca36e478c142813e59a8
 https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh8b19718_0.conda#511fbc2c63d2c73650ad1755e4d357ba
@@ -593,7 +588,7 @@ https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.c
 https://conda.anaconda.org/conda-forge/linux-64/geoarrow-rust-core-0.6.2-py312h0ccc70a_0.conda#8aeaa0800a5725dd9435d16553a8a62c
 https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-grpc-1.75.0-pyhcf101f3_0.conda#6dd8d1b2eb6676600cef70ec021bba3c
 https://conda.anaconda.org/conda-forge/noarch/grpcio-status-1.78.1-pyhcf101f3_0.conda#829271a8ea9d8024e99e43939ebb114f
-https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-mpi_mpich_h1a5cfed_5.conda#847f1a715e324125f8e67cffeb9a7887
+https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda#0d0595612fa229dddb5fc565c260a11f
 https://conda.anaconda.org/conda-forge/linux-64/hf-xet-1.5.0-py310hb823017_0.conda#0afe6c4582ddd164317cc4acf7f47c54
 https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda#4f14640d58e2cc0aa0819d9d8ba125bb
 https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-26.1.6-hecca717_0.conda#aaf7c3db8c7c4533deb5449d3ba1c51f
@@ -608,7 +603,6 @@ https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.3-he63569f_3.c
 https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda#8ae0593085ca8148fdbf0bc8f62e79c1
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2026.1.0-hb56ce9e_4.conda#bf0b7cde9e67d746db3dac68b563de77
 https://conda.anaconda.org/conda-forge/linux-64/libplacebo-7.360.1-h9eeb4b2_0.conda#e6324dfe6c02e0736bb9235f8ef3c8a6
-https://conda.anaconda.org/conda-forge/linux-64/libpnetcdf-1.14.1-mpi_mpich_h0009a5c_101.conda#2ec7034ce2c75d98ba3f73af3fecff08
 https://conda.anaconda.org/conda-forge/noarch/lsprotocol-2025.0.0-pyhe01879c_0.conda#f0680112562ae328ef9ce60545879cf9
 https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.0.0-h0e700b2_915.conda#44208bd851118db1e20923441f1bb3bb
 https://conda.anaconda.org/conda-forge/linux-64/nh3-0.3.5-py310hd8a072f_1.conda#8719dd226e9a128bd10033746e2418c6
@@ -627,14 +621,14 @@ https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.4.10-hdeec2a5_0.conda#845
 https://conda.anaconda.org/conda-forge/noarch/starlette-1.2.1-pyhcf101f3_0.conda#42f2b5375c39905cf8b020bbd85f687b
 https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda#32d866e43b25275f61566b9391ccb7b5
 https://conda.anaconda.org/conda-forge/noarch/typer-0.25.1-pyhcf101f3_0.conda#ef114c2eb2ff19f6bf616c81f4710841
-https://conda.anaconda.org/conda-forge/noarch/typeshed-client-2.11.0-pyhd8ed1ab_0.conda#c3a7fa6329c828929e6a8e3bc78f30b4
+https://conda.anaconda.org/conda-forge/noarch/typeshed-client-2.12.0-pyhd8ed1ab_0.conda#cde79417f6a4708f821b5d79b69005b2
 https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.2.0-py312h0ccc70a_0.conda#331d2437900a5e2d54641308d3445236
 https://conda.anaconda.org/conda-forge/noarch/watermark-2.6.0-pyhcf101f3_0.conda#05030c85ab3ec75ed1f9eb2b7fd62a74
 https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda#39f70aca52f1497a72eb9d81baf4d237
 https://conda.anaconda.org/conda-forge/noarch/anywidget-0.11.0-pyhd8ed1ab_0.conda#8037500885406e369aa2e7a28f74a3c2
 https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2#6b889f174df1e0f816276ae69281af4d
 https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.747-h41c0014_4.conda#169a79ea1127077d8dc36dc963ff55ac
-https://conda.anaconda.org/conda-forge/linux-64/awscli-2.34.58-py312h20c3967_0.conda#9c785409a34374d635bbdaf44345ed83
+https://conda.anaconda.org/conda-forge/linux-64/awscli-2.34.60-py312h20c3967_0.conda#b6573c0ff4ef231402878f918d28f41e
 https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.15.0-h1e5b466_0.conda#c9186aa979528963657db3e63c25e987
 https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda#057083b06ccf1c2778344b6dabace38b
 https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.136.3-pyhcf101f3_0.conda#af1c276d3cf531c643f89ec242d91564
@@ -654,7 +648,7 @@ https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h5875eb1_mkl.co
 https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.3-hf70aa56_3.conda#5429ab06028218ac67e11695b4b66a96
 https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.3-ha9bf034_3.conda#f019b2a48a736bf0357b0e24176ab941
 https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda#6f79d5f72cfcdd3509112233a8aedc2e
-https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-mpi_mpich_h65e3e28_4.conda#5954d774093fd57ba35ad04265c22a9e
+https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_h3c9b436_104.conda#6d38346d49e4638ec98649121d295d54
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.1.0-hd85de46_4.conda#9191d575b203fea7b901fa1391a772d8
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2026.1.0-hd85de46_4.conda#a62dce626d19df145aef38e790ea4b83
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2026.1.0-hd41364c_4.conda#95a9223e1ff6174a69d134a1ab805075
@@ -667,7 +661,7 @@ https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2026
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.1.0-hecca717_4.conda#b30fd90f32e047dc9363c882a34e926c
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.1.0-h78e8023_4.conda#3e08aabecc7cebfcc66ede56706b2b79
 https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.1.0-hecca717_4.conda#d8da10a17472a70071762e338a0d9977
-https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.2-h4c96295_0.conda#e318357f3d948cc16936d9f3b36cc7d9
+https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda#492c8d9b1c564c2e948b6cb4ba0f8261
 https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda#9f6b0090c3902b2c763a16f7dace7b6e
 https://conda.anaconda.org/conda-forge/noarch/msal-1.37.0-pyhd8ed1ab_0.conda#539593f9c2174c98c79cabe16fd25157
 https://conda.anaconda.org/conda-forge/noarch/multiurl-0.3.7-pyhd8ed1ab_0.conda#e585c71c2ed48e4eee1663d627ddcd47
@@ -690,7 +684,7 @@ https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.con
 https://conda.anaconda.org/conda-forge/noarch/boto3-1.43.0-pyhd8ed1ab_0.conda#c0587e9421bbe4660b9483a101895ef7
 https://conda.anaconda.org/conda-forge/linux-64/eccodes-2.47.0-ha1d8304_0.conda#3ef42f61d9a66a0749cbe598b5acdeea
 https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda#fc8b15af108a2fdb15ef04d12fbfe87d
-https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda#442ec6511754418c87a84bc1dc0c5384
+https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.24-pyhcf101f3_0.conda#517d72c5d62875c99fc0e6d4359a03f1
 https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.1.1-gpl_h58043d5_902.conda#844d3b4dbea878ef081aef26f3801f2f
 https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.30.3-pyhcf101f3_0.conda#fc99cddcd8e6b37d975781e54f1770de
 https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.4.0-pyhd8ed1ab_0.conda#6e998cbb5c02e7aecdab93dd6b289ede
@@ -705,15 +699,14 @@ https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h5e43f62_mkl.
 https://conda.anaconda.org/conda-forge/linux-64/msal_extensions-1.3.1-py312h7900ff3_1.conda#488750be5833a340ff2a8215883d7e4c
 https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda#00f5b8dafa842e0c27c1cd7296aa4875
 https://conda.anaconda.org/conda-forge/noarch/nbstripout-0.9.1-pyhd8ed1ab_0.conda#948b10290b9f4ebbb26de6da5c6b7c51
-https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-mpi_mpich_h67749c9_5.conda#fe8d6e0db37ccab85921a68868b9003b
-https://conda.anaconda.org/conda-forge/linux-64/parallelio-2.6.9-mpi_mpich_h462fbca_102.conda#61f401bc21aba557adbc3614b39bfa92
+https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-nompi_h4a60669_105.conda#19c44fef9eba50f926770ee530742b10
 https://conda.anaconda.org/conda-forge/noarch/planetary-computer-1.0.0-pyhd8ed1ab_1.conda#9477c2eb3a49f043c828384f277f29a6
 https://conda.anaconda.org/conda-forge/noarch/python-fasthtml-0.14.2-pyhc364b38_0.conda#2d744ba86924e0ed8e7869d91d8593f1
 https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.4.0-pyhd8ed1ab_0.conda#fef9f0284ba3717d02733cded0b67cce
 https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.30.1-hd72c24b_10.conda#d2b314a9d570c741523934656af8680c
 https://conda.anaconda.org/conda-forge/noarch/cdsapi-0.7.7-pyhd8ed1ab_0.conda#1f878573c1ee2798c052bee1f5a94f50
 https://conda.anaconda.org/conda-forge/noarch/earthaccess-0.18.0-pyhc364b38_0.conda#3ec59d2fd5976f413d75463241b6eab7
-https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-mpi_mpich_ha43e4ac_103.conda#b4ed7c955c215d632bfb745304f84d04
+https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-nompi_h0c1e4bb_3.conda#acd2eee9535335dede2a9eed181251c5
 https://conda.anaconda.org/conda-forge/noarch/fastapi-0.136.3-h5ddb490_0.conda#966cdb82bffe2677a8bc33a458c05675
 https://conda.anaconda.org/conda-forge/noarch/fastprogress-1.1.6-pyhd8ed1ab_0.conda#74db9c154d80f3acf9ff3d7a8775fc57
 https://conda.anaconda.org/conda-forge/noarch/google-cloud-core-2.5.1-pyhcf101f3_0.conda#4ddaf759564b096dfb8a3829d6e64c2d
@@ -797,7 +790,7 @@ https://conda.anaconda.org/conda-forge/linux-64/pyresample-1.35.0-py312h1289d80_
 https://conda.anaconda.org/conda-forge/linux-64/python-geotiepoints-1.9.0-py312h4f23490_1.conda#cd38da4b5d740b5505b4e0f68249540e
 https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.10.0-cuda130_mkl_py312_hbad622b_305.conda#34b01c755214c022963dccb3dd05bb21
 https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.5.0-py312hcedc861_0.conda#f0d110978a87b200a06412b56b26407c
-https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py312h3226591_1.conda#38decbeae260892040709cafc0514162
+https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py312h3226591_0.conda#e6e9b5795bb495325c3b4ebd451519aa
 https://conda.anaconda.org/conda-forge/noarch/sparse-0.18.0-pyhcf101f3_0.conda#c67d2c8ce612c88ece7221fe0b5357f2
 https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.6-py312h4f23490_0.conda#423b8676bd6eed60e97097b33f13ea3f
 https://conda.anaconda.org/conda-forge/noarch/tifffile-2026.6.1-pyhd8ed1ab_0.conda#b65b41dced5a938a5d8daa8c2403b973
@@ -864,7 +857,7 @@ https://conda.anaconda.org/conda-forge/noarch/pytorch-lightning-2.6.5-pyhcf101f3
 https://conda.anaconda.org/conda-forge/noarch/rio-cogeo-7.0.2-pyhd8ed1ab_0.conda#0e48d784796728f7d9eef58b930a32d0
 https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda#62afb877ca2c2b4b6f9ecb37320085b6
 https://conda.anaconda.org/conda-forge/noarch/timm-1.0.27-pyhcf101f3_0.conda#59a0c3968e59e6ce52855ef9bc9ff421
-https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.1-pyhd8ed1ab_0.conda#bcbb516ee86e84254906cc1aeb4b0216
+https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.2-pyhd8ed1ab_0.conda#235b842dd45d73f515394e640db614c5
 https://conda.anaconda.org/conda-forge/noarch/xarray_leaflet-0.2.3-pyhd8ed1ab_1.conda#d10236fbf76eb421ceb14b6a57004b8b
 https://conda.anaconda.org/conda-forge/noarch/xgboost-3.2.0-cuda132_pyh7b4a8e3_2.conda#d46e1fa3779999420d11b7d51159ce7a
 https://conda.anaconda.org/conda-forge/noarch/xmip-0.7.2-pyhd8ed1ab_1.conda#ed2575dbbcac52e1f4c79669fdd7abce
@@ -876,7 +869,7 @@ https://conda.anaconda.org/conda-forge/noarch/dask-geopandas-0.5.0-pyhd8ed1ab_0.
 https://conda.anaconda.org/conda-forge/noarch/geocube-0.7.1-pyhd8ed1ab_0.conda#5d905eadd1a60abeb09fd636dedce3e2
 https://conda.anaconda.org/conda-forge/noarch/intake-geopandas-0.4.0-pyhd8ed1ab_1.conda#b1e2b5665d15c2d62d99bec8aedda0da
 https://conda.anaconda.org/conda-forge/noarch/lightly-1.15.22-pyhd8ed1ab_0.conda#86f33f18a790ba4f98a5192b50d2f99f
-https://conda.anaconda.org/conda-forge/noarch/lightning-2.6.1-pyhcf101f3_0.conda#45ffefa6c982ae45df735719b8dfe9a1
+https://conda.anaconda.org/conda-forge/noarch/lightning-2.6.5-pyhcf101f3_0.conda#ecb6d9985a3249d2132580cd605b8e65
 https://conda.anaconda.org/conda-forge/noarch/nb_conda_kernels-2.5.1-pyh707e725_2.conda#076e6d822442987779a6622092a8fb6a
 https://conda.anaconda.org/conda-forge/noarch/nbgitpuller-1.2.2-pyhd8ed1ab_0.conda#019d57ba0caa278271739377a656da20
 https://conda.anaconda.org/conda-forge/noarch/odc-stac-0.5.2-pyhd8ed1ab_0.conda#1cd445dd25c65092fabc8b20229537d5

--- a/pytorch-notebook/conda-lock.yml
+++ b/pytorch-notebook/conda-lock.yml
@@ -380,28 +380,28 @@ package:
   category: main
   optional: false
 - name: alsa-lib
-  version: 1.2.15.3
+  version: 1.2.16
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
   hash:
-    md5: dcdc58c15961dbf17a0621312b01f5cb
-    sha256: d88aa7ae766cf584e180996e92fef2aa7d8e0a0a5ab1d4d49c32390c1b5fff31
+    md5: 18d273b22e96c97c2017813f099faa82
+    sha256: 64484cb7e7cf65d9c7188498d595125a6e0751604dd7fb483e1bb327eec0f738
   category: main
   optional: false
 - name: alsa-lib
-  version: 1.2.15.3
+  version: 1.2.16
   manager: conda
   platform: linux-aarch64
   dependencies:
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.15.3-he30d5cf_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.16-he30d5cf_0.conda
   hash:
-    md5: 4a98cbc4ade694520227402ff8880630
-    sha256: ea2233e2db9908c2e5f29d3ca420a546b4583253f4f70abb5494cdd676866d42
+    md5: 20e118f10dc11b6b2383ae7c1f2c8e8c
+    sha256: 722a24bb4a2faabcedf694ae494393e6f9b698dddbf0782fb0dcd7bfcc0c2027
   category: main
   optional: false
 - name: amqp
@@ -1667,7 +1667,7 @@ package:
   category: main
   optional: false
 - name: awscli
-  version: 2.34.58
+  version: 2.34.60
   manager: conda
   platform: linux-64
   dependencies:
@@ -1684,14 +1684,14 @@ package:
     ruamel.yaml.clib: '>=0.2.0,<=0.2.15'
     urllib3: '>=1.25.4,<=2.6.3'
     wcwidth: <0.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.34.58-py312h20c3967_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.34.60-py312h20c3967_0.conda
   hash:
-    md5: 9c785409a34374d635bbdaf44345ed83
-    sha256: 5b5e7a6c284fb432dfc18b9de8e4b87efffa3b148a13be89b91c1551bf940c79
+    md5: b6573c0ff4ef231402878f918d28f41e
+    sha256: 5a313f960796561db57957cd815f6c2e8e3ee81d73a5c06161afb2b723db0604
   category: main
   optional: false
 - name: awscli
-  version: 2.34.58
+  version: 2.34.60
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -1708,10 +1708,10 @@ package:
     ruamel.yaml.clib: '>=0.2.0,<=0.2.15'
     urllib3: '>=1.25.4,<=2.6.3'
     wcwidth: <0.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/awscli-2.34.58-py312h6d8504a_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/awscli-2.34.60-py312h6d8504a_0.conda
   hash:
-    md5: 16ce6bfb777be8b6d5c770d0c040efbc
-    sha256: fcbc2a81db3634c7ff550d75d155558b99f6e44649c62d2534080096cb6785fe
+    md5: 28b82d44c15d5466d4ecb9f1502785f2
+    sha256: 2edac0ec78afb1b2348b337843428b9e555a34c588e47bf549927605899aad6a
   category: main
   optional: false
 - name: awscrt
@@ -4617,7 +4617,7 @@ package:
   category: main
   optional: false
 - name: debugpy
-  version: 1.8.20
+  version: 1.8.21
   manager: conda
   platform: linux-64
   dependencies:
@@ -4626,10 +4626,10 @@ package:
     libstdcxx: '>=14'
     python: ''
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py312h8285ef7_0.conda
   hash:
-    md5: ee1b48795ceb07311dd3e665dd4f5f33
-    sha256: f20121b67149ff80bf951ccae7442756586d8789204cd08ade59397b22bfd098
+    md5: e6778419a1851f6e15820558abddfa04
+    sha256: b8dbe25820064a099f315bbb8f45f5bac3fddb63e96af3cbf0c93a830733ef34
   category: main
   optional: false
 - name: debugpy
@@ -5372,13 +5372,11 @@ package:
     libgfortran5: '>=14.3.0'
     libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libstdcxx: '>=14'
-    mpich: '>=5.0,<6.0a0'
     netcdf-fortran: '>=4.6.2,<4.7.0a0'
-    parallelio: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-mpi_mpich_ha43e4ac_103.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-nompi_h0c1e4bb_3.conda
   hash:
-    md5: b4ed7c955c215d632bfb745304f84d04
-    sha256: df29582456e3091ab5d0e7b7b2f1fd221dc829b8ca5603b45bc5fcd19d737bc5
+    md5: acd2eee9535335dede2a9eed181251c5
+    sha256: 7c91329051080f64fe81fd7346600bc07feaa60c102abc842f2b9b3c7a1d35aa
   category: main
   optional: false
 - name: esmf
@@ -5392,13 +5390,11 @@ package:
     libgfortran5: '>=14.3.0'
     libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libstdcxx: '>=14'
-    mpich: '>=5.0,<6.0a0'
     netcdf-fortran: '>=4.6.2,<4.7.0a0'
-    parallelio: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/esmf-8.9.1-mpi_mpich_hb075c57_103.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/esmf-8.9.1-nompi_h8ba66ce_3.conda
   hash:
-    md5: a51b89da8bdb8581aad8aadc506348b2
-    sha256: 5ed69d1aca9028efa3b47d56d708ad286469aa8c935ccadfc2664649b98ff21e
+    md5: c8d13ca44f86b5986c72bc43e671f6bf
+    sha256: ac18906a66b8f983b0ba6d4ff29e52f871c25c66328cac3c2bc12ad2e335fc36
   category: main
   optional: false
 - name: esmpy
@@ -5522,35 +5518,35 @@ package:
   category: main
   optional: false
 - name: fastapi-cli
-  version: 0.0.23
+  version: 0.0.24
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
     rich-toolkit: '>=0.14.8'
     tomli: '>=2.0.0'
-    typer: '>=0.15.1'
+    typer: '>=0.16'
     uvicorn-standard: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.24-pyhcf101f3_0.conda
   hash:
-    md5: 442ec6511754418c87a84bc1dc0c5384
-    sha256: cb60fc8c96dcd2a6335914d4d6d7d5f5549c9e1ff4533be28ba699e648babf37
+    md5: 517d72c5d62875c99fc0e6d4359a03f1
+    sha256: 0c13b515d4424587b97dd6ede9277a659a1f580608faf3ab43341bf95a270aca
   category: main
   optional: false
 - name: fastapi-cli
-  version: 0.0.23
+  version: 0.0.24
   manager: conda
   platform: linux-aarch64
   dependencies:
     python: ''
     rich-toolkit: '>=0.14.8'
     tomli: '>=2.0.0'
-    typer: '>=0.15.1'
+    typer: '>=0.16'
     uvicorn-standard: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.24-pyhcf101f3_0.conda
   hash:
-    md5: 442ec6511754418c87a84bc1dc0c5384
-    sha256: cb60fc8c96dcd2a6335914d4d6d7d5f5549c9e1ff4533be28ba699e648babf37
+    md5: 517d72c5d62875c99fc0e6d4359a03f1
+    sha256: 0c13b515d4424587b97dd6ede9277a659a1f580608faf3ab43341bf95a270aca
   category: main
   optional: false
 - name: fastapi-core
@@ -6168,7 +6164,7 @@ package:
   category: main
   optional: false
 - name: fontconfig
-  version: 2.18.0
+  version: 2.18.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -6179,14 +6175,14 @@ package:
     libgcc: '>=14'
     libuuid: '>=2.42.1,<3.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.0-h27c8c51_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
   hash:
-    md5: 06965b2f9854d0b15e0443ee81fe83dc
-    sha256: e798086d8a65d55dc4c51f5746705639c9a5f2eeb0b8fc50e6152cfc0d69a4e8
+    md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+    sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
   category: main
   optional: false
 - name: fontconfig
-  version: 2.18.0
+  version: 2.18.1
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -6196,10 +6192,10 @@ package:
     libgcc: '>=14'
     libuuid: '>=2.42.1,<3.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.0-hba86a56_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
   hash:
-    md5: b660d59a9d0fb3297327418624acaec3
-    sha256: 1805f4ab3d9e1734a5a17abccc2cb0fdade51d4d5f29bdc410600ea0115ec050
+    md5: f4d29a0cd77104a683607319a542ac7e
+    sha256: 2ccfd118269d363a5506161c4a0d96da46d2f01beecc74e0540a54b4737d0e45
   category: main
   optional: false
 - name: fonts-conda-ecosystem
@@ -7431,29 +7427,29 @@ package:
   category: main
   optional: false
 - name: google-cloud-sdk
-  version: 570.0.0
+  version: 571.0.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-570.0.0-py312h7900ff3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-571.0.0-py312h7900ff3_0.conda
   hash:
-    md5: c4663cdd2a4653c0a84f95a0227c9b8d
-    sha256: 9b00e1ac3dfd5a60c6d15c90f6f367e2a96d788c026358bdddae0ece489c3dcc
+    md5: dedf2ef75d0f01c92e73df4bfccb0a3c
+    sha256: 8c6beb9954409803f00fdbf31297645e85cae56136ca68d25d184a85be451fe8
   category: main
   optional: false
 - name: google-cloud-sdk
-  version: 570.0.0
+  version: 571.0.0
   manager: conda
   platform: linux-aarch64
   dependencies:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/google-cloud-sdk-570.0.0-py312h996f985_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/google-cloud-sdk-571.0.0-py312h996f985_0.conda
   hash:
-    md5: 06ff8b97da474d3b24c41cd654ea8677
-    sha256: c2ec58c48687d34298bf3deba488779c56a2bc5aeaaf48d9dfc0d17ae690da1d
+    md5: a5fe89f1a5507e06fbde509b0fee2482
+    sha256: 6de5caa877992a86878654a4497bff32c104bfb6fc9b2f0b995f0ae5d088132a
   category: main
   optional: false
 - name: google-cloud-storage
@@ -7678,30 +7674,30 @@ package:
   category: main
   optional: false
 - name: graphite2
-  version: 1.3.14
+  version: 1.3.15
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
   hash:
-    md5: 2cd94587f3a401ae05e03a6caf09539d
-    sha256: 25ba37da5c39697a77fce2c9a15e48cf0a84f1464ad2aafbe53d8357a9f6cc8c
+    md5: cf09e9fc938518e91d0706572cadf17a
+    sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
   category: main
   optional: false
 - name: graphite2
-  version: 1.3.14
+  version: 1.3.15
   manager: conda
   platform: linux-aarch64
   dependencies:
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-hfae3067_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
   hash:
-    md5: 4aa540e9541cc9d6581ab23ff2043f13
-    sha256: c9b1781fe329e0b77c5addd741e58600f50bef39321cae75eba72f2f381374b7
+    md5: 4db044857ab1d09b2e8f0013c65387c1
+    sha256: 3e529c517a76a1f4497c51eeedeeb927d33f732dcdb48055a020a83eb3e4e95c
   category: main
   optional: false
 - name: graphviz
@@ -8272,7 +8268,7 @@ package:
   category: main
   optional: false
 - name: harfbuzz
-  version: 14.2.0
+  version: 14.2.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -8280,38 +8276,38 @@ package:
     cairo: '>=1.18.4,<2.0a0'
     graphite2: '>=1.3.14,<2.0a0'
     icu: '>=78.3,<79.0a0'
-    libexpat: '>=2.7.5,<3.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libglib: '>=2.86.4,<3.0a0'
+    libglib: '>=2.88.1,<3.0a0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
   hash:
-    md5: e194f6a2f498f0c7b1e6498bd0b12645
-    sha256: 232c95b56d16d33d8256026a3b1ad34f7f9a75c179d388854be0fd624ddba9e3
+    md5: 21ee4640b7c2d94e584349fa12b29b9a
+    sha256: da9901aa1e20cbc2369fda212039b294dd02bce95f005539bab840b7310bf7d0
   category: main
   optional: false
 - name: harfbuzz
-  version: 14.2.0
+  version: 14.2.1
   manager: conda
   platform: linux-aarch64
   dependencies:
     cairo: '>=1.18.4,<2.0a0'
     graphite2: '>=1.3.14,<2.0a0'
     icu: '>=78.3,<79.0a0'
-    libexpat: '>=2.7.5,<3.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libglib: '>=2.86.4,<3.0a0'
+    libglib: '>=2.88.1,<3.0a0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.0-h1134a53_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h1134a53_0.conda
   hash:
-    md5: 1775defbef30aa990498e753a948cb18
-    sha256: cb3e67e8045577b944b64534907d194ebc44e0959e0842847c18a4067eeeb9f6
+    md5: 5f3ec279ab7cc391b7dff69dc08298fa
+    sha256: 17a671aa62e1f0a8750514353e3d6e9aab80598908d9b107fc7f3cf7972176b6
   category: main
   optional: false
 - name: hdf4
@@ -8363,12 +8359,11 @@ package:
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
     openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-mpi_mpich_h1a5cfed_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda
   hash:
-    md5: 847f1a715e324125f8e67cffeb9a7887
-    sha256: 1ac07a4d7404fd6255b6aefee3f98b98e2263c22214555342ec0715dc134e428
+    md5: 0d0595612fa229dddb5fc565c260a11f
+    sha256: beb8a2fb18924ca7b5b82cfb50f008f882f577daef2c00ed88022abea35fec76
   category: main
   optional: false
 - name: hdf5
@@ -8389,12 +8384,11 @@ package:
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
     openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-2.1.0-mpi_mpich_h37d1499_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h6ea7a3c_105.conda
   hash:
-    md5: 7d08a65e504b3570ec6fc9ea7861ffbf
-    sha256: 83982d2ff55c50a9ddce3af667a79fdc9b28744a0bf50a9d9da06e4ed84de7ca
+    md5: 076103ea89b838e3e20b96985be64e88
+    sha256: 3f58ef9b51335d6f4a57d851de1c017eda4c12f3857b3f7722aeba6a6d30f9c8
   category: main
   optional: false
 - name: heapdict
@@ -12604,60 +12598,6 @@ package:
     sha256: 1fc392b997c6ee2bd3226a7cd870d0edbcbb367e25f9f18dd4a7025fced6efc0
   category: main
   optional: false
-- name: libfabric
-  version: 2.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libfabric1: 2.5.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.1-ha770c72_1.conda
-  hash:
-    md5: 0b82ff1ab3db9122f20cafe93f61bc3b
-    sha256: c2b53beed03c735b18116d5227410b15cc9fbef209795212afd179f8c8a5fd70
-  category: main
-  optional: false
-- name: libfabric
-  version: 2.5.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libfabric1: 2.5.1
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libfabric-2.5.1-h8af1aa0_1.conda
-  hash:
-    md5: 192389236af398fec30a73cd2f6e441a
-    sha256: b4a9429a4dba4029543ae999b3a72625b07f6c10c9b096ad3cdeee206ac83657
-  category: main
-  optional: false
-- name: libfabric1
-  version: 2.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    libgcc: '>=14'
-    libnl: '>=3.11.0,<4.0a0'
-    rdma-core: '>=63.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.1-h6b3ec72_1.conda
-  hash:
-    md5: 4a7168d686b6125ba546134dddb16721
-    sha256: f64b69e48636871081fde0604ed37fac32a7146073ad2899550bcc0b14e7c09d
-  category: main
-  optional: false
-- name: libfabric1
-  version: 2.5.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    libgcc: '>=14'
-    libnl: '>=3.11.0,<4.0a0'
-    rdma-core: '>=63.0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libfabric1-2.5.1-h6b50f16_1.conda
-  hash:
-    md5: 447a66768c019e33a2c38ee4de92a101
-    sha256: 8106cca3dd8a0a16cfcb2855e092c651ec5bca6989fcad2c4962640a16ad7c70
-  category: main
-  optional: false
 - name: libffi
   version: 3.5.2
   manager: conda
@@ -13846,19 +13786,17 @@ package:
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.19.0,<9.0a0'
     libgcc: '>=14'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
     libstdcxx: '>=14'
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libzip: '>=1.11.2,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
     openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-mpi_mpich_h65e3e28_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_h3c9b436_104.conda
   hash:
-    md5: 5954d774093fd57ba35ad04265c22a9e
-    sha256: 02f09c75003e2bd6077821e331ec1e7c85789a99ddee0ccf7f9108add2244d7f
+    md5: 6d38346d49e4638ec98649121d295d54
+    sha256: 6a1dbee34abe246c32abb89bd35855c25551de09562a719da97c4e5975f5f035
   category: main
   optional: false
 - name: libnetcdf
@@ -13873,19 +13811,17 @@ package:
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.19.0,<9.0a0'
     libgcc: '>=14'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
     libstdcxx: '>=14'
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libzip: '>=1.11.2,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
     openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnetcdf-4.10.0-mpi_mpich_h9c907d1_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnetcdf-4.10.0-nompi_h441b98c_104.conda
   hash:
-    md5: 1ec225ddf0c9adab9e2d3d83a792f79e
-    sha256: 276648722f603e91266be2c17662846a336960010f2b62a4ee127d621db89575
+    md5: a6690e6628694b3a972ca973244180d9
+    sha256: 88002596e0e26d387c7091bce8672cfd87a1dec695b600e0ef55789f7ad8618a
   category: main
   optional: false
 - name: libnghttp2
@@ -14660,39 +14596,6 @@ package:
     sha256: 3af9437023ec7fa8f9bf5e390b7f6ad3df403aa736b0305121d1734af2d0620e
   category: main
   optional: false
-- name: libpnetcdf
-  version: 1.14.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libstdcxx: '>=14'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpnetcdf-1.14.1-mpi_mpich_h0009a5c_101.conda
-  hash:
-    md5: 2ec7034ce2c75d98ba3f73af3fecff08
-    sha256: 37bb953c0f6edeca52545dd4e43833348c3953be42d9c78315b4b0b627586c11
-  category: main
-  optional: false
-- name: libpnetcdf
-  version: 1.14.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libstdcxx: '>=14'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpnetcdf-1.14.1-mpi_mpich_h475dd2c_101.conda
-  hash:
-    md5: 128abe992c2c20bb6394e45b5dbb4515
-    sha256: d9988e5934480100b1031c335e07c7df5d2b3427ac0619243fe17caca15b30be
-  category: main
-  optional: false
 - name: libpng
   version: 1.6.58
   manager: conda
@@ -14781,13 +14684,13 @@ package:
   category: main
   optional: false
 - name: librsvg
-  version: 2.62.2
+  version: 2.62.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     cairo: '>=1.18.4,<2.0a0'
-    fontconfig: '>=2.17.1,<3.0a0'
+    fontconfig: '>=2.18.0,<3.0a0'
     fonts-conda-ecosystem: ''
     gdk-pixbuf: '>=2.44.6,<3.0a0'
     harfbuzz: '>=14.2.0'
@@ -14795,19 +14698,19 @@ package:
     libglib: '>=2.88.1,<3.0a0'
     libxml2-16: '>=2.14.6'
     pango: '>=1.56.4,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.2-h4c96295_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
   hash:
-    md5: e318357f3d948cc16936d9f3b36cc7d9
-    sha256: 864d93b0385778c7495c369d9df408e2b436ef136c8f7de645e25fd461acc553
+    md5: 492c8d9b1c564c2e948b6cb4ba0f8261
+    sha256: 5571bd8239d71961d4e3ce972f865b3ea95a91ce0b53d5749fe2dd24254ddbda
   category: main
   optional: false
 - name: librsvg
-  version: 2.62.2
+  version: 2.62.3
   manager: conda
   platform: linux-aarch64
   dependencies:
     cairo: '>=1.18.4,<2.0a0'
-    fontconfig: '>=2.17.1,<3.0a0'
+    fontconfig: '>=2.18.0,<3.0a0'
     fonts-conda-ecosystem: ''
     gdk-pixbuf: '>=2.44.6,<3.0a0'
     harfbuzz: '>=14.2.0'
@@ -14815,10 +14718,10 @@ package:
     libglib: '>=2.88.1,<3.0a0'
     libxml2-16: '>=2.14.6'
     pango: '>=1.56.4,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.62.2-hf685517_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.62.3-hf685517_0.conda
   hash:
-    md5: aa215afd17a243a4394f2297f83651e2
-    sha256: 427486a9eae80874223a3f24fdbf16123330f7a7d89cacee88b460123038d0de
+    md5: 38209cc04b3e3e5624c534bc703e6939
+    sha256: c95ac70755863d8522c1115b54afca86148ea25366b616aa84c993c2ca54b9ce
   category: main
   optional: false
 - name: librttopo
@@ -16055,7 +15958,7 @@ package:
   category: main
   optional: false
 - name: lightning
-  version: 2.6.1
+  version: 2.6.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -16069,14 +15972,14 @@ package:
     torchmetrics: <3.0,>0.7.0
     tqdm: <6.0,>=4.57.0
     typing_extensions: <6.0,>4.5.0
-  url: https://conda.anaconda.org/conda-forge/noarch/lightning-2.6.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/lightning-2.6.5-pyhcf101f3_0.conda
   hash:
-    md5: 45ffefa6c982ae45df735719b8dfe9a1
-    sha256: 38d5f2eab56888ce5f15493e845a099381a1120b7ab0fcfeb1b08029630660f6
+    md5: ecb6d9985a3249d2132580cd605b8e65
+    sha256: a55523823fff3b59a2037cdb6d994d299202dc817ee0fbba44a668b979edfe08
   category: main
   optional: false
 - name: lightning
-  version: 2.6.1
+  version: 2.6.5
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -16090,10 +15993,10 @@ package:
     torchmetrics: <3.0,>0.7.0
     tqdm: <6.0,>=4.57.0
     typing_extensions: <6.0,>4.5.0
-  url: https://conda.anaconda.org/conda-forge/noarch/lightning-2.6.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/lightning-2.6.5-pyhcf101f3_0.conda
   hash:
-    md5: 45ffefa6c982ae45df735719b8dfe9a1
-    sha256: 38d5f2eab56888ce5f15493e845a099381a1120b7ab0fcfeb1b08029630660f6
+    md5: ecb6d9985a3249d2132580cd605b8e65
+    sha256: a55523823fff3b59a2037cdb6d994d299202dc817ee0fbba44a668b979edfe08
   category: main
   optional: false
 - name: lightning-utilities
@@ -16218,26 +16121,26 @@ package:
   category: main
   optional: false
 - name: llvm-openmp
-  version: 22.1.6
+  version: 22.1.7
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.6-h4922eb0_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.7-h4922eb0_0.conda
   hash:
-    md5: a7f80a18bc21daad0f4d5c3fbad1e8c1
-    sha256: e74dbafd2b420687cc913f5587050270c8f57042405b6b0d66c3a8013dc104ab
+    md5: 362702bd1f3c1b06ba5908ff18ef6d8c
+    sha256: 41941a6edc8358ec41617252cfec6b9e560cdfdf6d5a5c7d3c2562f43a3b66cb
   category: main
   optional: false
 - name: llvm-openmp
-  version: 22.1.6
+  version: 22.1.7
   manager: conda
   platform: linux-aarch64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/llvm-openmp-22.1.6-he40846f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/llvm-openmp-22.1.7-he40846f_0.conda
   hash:
-    md5: 1d23af40dafb36d1b31c804429159d75
-    sha256: 3561632a8833728855eb753eaeb35c2a9e7e2bd3c50faa74947235a8403b71ba
+    md5: 47caf591958c074aa303667702de9e30
+    sha256: 735e015fa7e3e1b218ab05f17e590cfe2a58228db45d1e5e6dddbaa94f57003b
   category: main
   optional: false
 - name: llvmlite
@@ -17067,69 +16970,6 @@ package:
     sha256: d65d5a00278544639ba4f99887154be00a1f57afb0b34d80b08e5cba40a17072
   category: main
   optional: false
-- name: mpi
-  version: 1.0.1
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-mpich.conda
-  hash:
-    md5: 1052de900d672ec8b3713b8e300a8f06
-    sha256: eacc189267202669a1c5c849dcca2298f41acb3918f05cf912d7d61ee7176fac
-  category: main
-  optional: false
-- name: mpi
-  version: 1.0.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-mpich.conda
-  hash:
-    md5: 1052de900d672ec8b3713b8e300a8f06
-    sha256: eacc189267202669a1c5c849dcca2298f41acb3918f05cf912d7d61ee7176fac
-  category: main
-  optional: false
-- name: mpich
-  version: 5.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libfabric: ''
-    libfabric1: '>=1.14.0'
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libhwloc: '>=2.13.0,<2.13.1.0a0'
-    libstdcxx: '>=14'
-    mpi: 1.0.*
-    ucx: '>=1.20.0,<1.21.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpich-5.0.1-h6f9170e_0.conda
-  hash:
-    md5: 47a868b6ab372a8623f2a612d5979940
-    sha256: 6ebda028cde067c9effa285660e9c3e81361a700ac3b13d6b400ef9c4fbaa316
-  category: main
-  optional: false
-- name: mpich
-  version: 5.0.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libfabric: ''
-    libfabric1: '>=1.14.0'
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libhwloc: '>=2.13.0,<2.13.1.0a0'
-    libstdcxx: '>=14'
-    mpi: 1.0.*
-    ucx: '>=1.20.0,<1.21.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mpich-5.0.1-hc4b3ac6_0.conda
-  hash:
-    md5: 315b6a87ea80f8253e385271c0ca4763
-    sha256: d366dbc16fd8cd41cfdb3a8ac68d477009c3ef344316d5c5b1d535b5ba3c3026
-  category: main
-  optional: false
 - name: mpmath
   version: 1.3.0
   manager: conda
@@ -17853,11 +17693,10 @@ package:
     libgfortran5: '>=14.3.0'
     libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-mpi_mpich_h67749c9_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-nompi_h4a60669_105.conda
   hash:
-    md5: fe8d6e0db37ccab85921a68868b9003b
-    sha256: 5226b4af7b4581e1fc0b02b93f7c2aeb68daa59a06dcf3271a4fc8c3b007e7ef
+    md5: 19c44fef9eba50f926770ee530742b10
+    sha256: 5df7a482cd3ed296fb56b3d4dca0755673f768e5fc244e27e44d5d8a9975e9ee
   category: main
   optional: false
 - name: netcdf-fortran
@@ -17871,11 +17710,10 @@ package:
     libgfortran5: '>=14.3.0'
     libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/netcdf-fortran-4.6.2-mpi_mpich_h879aca7_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/netcdf-fortran-4.6.2-nompi_hcd9d1cc_105.conda
   hash:
-    md5: ea6b294afc4d0809bd3fed8600f9514a
-    sha256: 800977afb5087a09683e742e41cc682e7bcf71446d92207e0fee3942e346d297
+    md5: 6fa8376a86744dcc6f0f060f04a6e8c5
+    sha256: ec5c25624c0b08a00680ee66bffd789a46c2b4efafb0d1bad49f8f288829467a
   category: main
   optional: false
 - name: netcdf4
@@ -19157,41 +18995,6 @@ package:
   hash:
     md5: 3fc7cc25bba3381e77b753578058e3b0
     sha256: d209c8b0d53c441ee0bc0d8fce0fcae8e7e05755e51b13b6b9da02c7aa032f98
-  category: main
-  optional: false
-- name: parallelio
-  version: 2.6.9
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libnetcdf: '>=4.10.0,<4.10.1.0a0'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/parallelio-2.6.9-mpi_mpich_h462fbca_102.conda
-  hash:
-    md5: 61f401bc21aba557adbc3614b39bfa92
-    sha256: 31d3f1efeaa55109c287f3930ca3627e377f699ad2571d714cbadd8784f8b7af
-  category: main
-  optional: false
-- name: parallelio
-  version: 2.6.9
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libnetcdf: '>=4.10.0,<4.10.1.0a0'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
-    mpich: '>=5.0,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/parallelio-2.6.9-mpi_mpich_hb506b6b_102.conda
-  hash:
-    md5: 2ac97e68ed8417beb45993cc37db77c6
-    sha256: 585f0286e787ec659fac9742cb47a2f9254e88ad014f2350b29fcbf0e9118a59
   category: main
   optional: false
 - name: param
@@ -23378,44 +23181,46 @@ package:
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.8.0
+  version: 1.9.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-    joblib: '>=1.3.0'
+    joblib: '>=1.4.0'
     libgcc: '>=14'
     libstdcxx: '>=14'
+    narwhals: '>=2.0.1'
     numpy: '>=1.23,<3'
     python: ''
     python_abi: 3.12.*
     scipy: '>=1.10.0'
-    threadpoolctl: '>=3.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py312h3226591_1.conda
+    threadpoolctl: '>=3.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py312h3226591_0.conda
   hash:
-    md5: 38decbeae260892040709cafc0514162
-    sha256: 23c643c37fafa14ba3f2b7a407126ea5e732a3655ea8157cf9f977098f863448
+    md5: e6e9b5795bb495325c3b4ebd451519aa
+    sha256: 8c0cd0326b5a17ddcf189fc4f119bf6871b7853595c088075847c484a3ed567e
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.8.0
+  version: 1.9.0
   manager: conda
   platform: linux-aarch64
   dependencies:
     _openmp_mutex: '>=4.5'
-    joblib: '>=1.3.0'
+    joblib: '>=1.4.0'
     libgcc: '>=14'
     libstdcxx: '>=14'
+    narwhals: '>=2.0.1'
     numpy: '>=1.23,<3'
     python: 3.12.*
     python_abi: 3.12.*
     scipy: '>=1.10.0'
-    threadpoolctl: '>=3.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/scikit-learn-1.8.0-np2py312hca49013_1.conda
+    threadpoolctl: '>=3.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/scikit-learn-1.9.0-np2py312hca49013_0.conda
   hash:
-    md5: 4ee0a99cdf60dad5d9349985e14ee737
-    sha256: 6cdf1363ea485c6f7fc14c302bcea347308b4343200bda94d7a38b0dbb8c0e87
+    md5: 534988ee816470b09273e8c83b2950e5
+    sha256: 83c12ba5973b1c0963904adc329709055b26e8137c040d423ed5dfd8c4382f6c
   category: main
   optional: false
 - name: scipy
@@ -25098,27 +24903,27 @@ package:
   category: main
   optional: false
 - name: traitlets
-  version: 5.15.0
+  version: 5.15.1
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
-    md5: 4bada6a6d908a27262af8ebddf4f7492
-    sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
+    md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+    sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
   category: main
   optional: false
 - name: traitlets
-  version: 5.15.0
+  version: 5.15.1
   manager: conda
   platform: linux-aarch64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
-    md5: 4bada6a6d908a27262af8ebddf4f7492
-    sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
+    md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+    sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
   category: main
   optional: false
 - name: traittypes
@@ -25235,27 +25040,27 @@ package:
   category: main
   optional: false
 - name: trollsift
-  version: 1.0.0
+  version: 1.0.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c9e0f517471f71f4a5ebac45ae3bbfa2
-    sha256: aa76ba7c535a4bcc297c9454bb9aeb873c1f8ad3b1e4c246908670ba7fd475c7
+    md5: f811b6bf76aba2311c448d5cedaaf080
+    sha256: 99a9f09f73df6bf374c240fc243acb0af3987f9d0725e5ed44215429e712f5b3
   category: main
   optional: false
 - name: trollsift
-  version: 1.0.0
+  version: 1.0.1
   manager: conda
   platform: linux-aarch64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-1.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c9e0f517471f71f4a5ebac45ae3bbfa2
-    sha256: aa76ba7c535a4bcc297c9454bb9aeb873c1f8ad3b1e4c246908670ba7fd475c7
+    md5: f811b6bf76aba2311c448d5cedaaf080
+    sha256: 99a9f09f73df6bf374c240fc243acb0af3987f9d0725e5ed44215429e712f5b3
   category: main
   optional: false
 - name: typer
@@ -25291,31 +25096,31 @@ package:
   category: main
   optional: false
 - name: typeshed-client
-  version: 2.11.0
+  version: 2.12.0
   manager: conda
   platform: linux-64
   dependencies:
     importlib-resources: '>=1.4.0'
     python: '>=3.9'
     typing-extensions: '>=4.5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typeshed-client-2.11.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typeshed-client-2.12.0-pyhd8ed1ab_0.conda
   hash:
-    md5: c3a7fa6329c828929e6a8e3bc78f30b4
-    sha256: 31467385f2b959088d115858ed05925b3779967dc3c3b4a5870483b446336d5a
+    md5: cde79417f6a4708f821b5d79b69005b2
+    sha256: cbbd682b7aa03e79d963c89499f683ee49374c490a91a1202bd3478ea2791ecb
   category: main
   optional: false
 - name: typeshed-client
-  version: 2.11.0
+  version: 2.12.0
   manager: conda
   platform: linux-aarch64
   dependencies:
     importlib-resources: '>=1.4.0'
     python: '>=3.9'
     typing-extensions: '>=4.5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typeshed-client-2.11.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typeshed-client-2.12.0-pyhd8ed1ab_0.conda
   hash:
-    md5: c3a7fa6329c828929e6a8e3bc78f30b4
-    sha256: 31467385f2b959088d115858ed05925b3779967dc3c3b4a5870483b446336d5a
+    md5: cde79417f6a4708f821b5d79b69005b2
+    sha256: cbbd682b7aa03e79d963c89499f683ee49374c490a91a1202bd3478ea2791ecb
   category: main
   optional: false
 - name: typing-extensions
@@ -25460,38 +25265,6 @@ package:
   hash:
     md5: 4fdd327852ffefc83173a7c029690d0c
     sha256: 9e5a0e70e876fca50de075b1cc6641cdc009a16c18f4d52ab03edb777729a1bc
-  category: main
-  optional: false
-- name: ucx
-  version: 1.20.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    rdma-core: '>=61.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.20.1-hf72d326_0.conda
-  hash:
-    md5: 227baf40539ae6858afe99634faf883d
-    sha256: 96341dbb30e77b0c89522f850edc42572a0d7937646898bb2d57b93a5c348e0c
-  category: main
-  optional: false
-- name: ucx
-  version: 1.20.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    rdma-core: '>=61.0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ucx-1.20.1-h62a42b4_0.conda
-  hash:
-    md5: d99452fecc606351f25b789f903c8e00
-    sha256: c74d15f5734c09a60ee0bc12c30eba325ec7d72afaa50781ec7dcc5a763f22fd
   category: main
   optional: false
 - name: ujson
@@ -26393,7 +26166,7 @@ package:
   category: main
   optional: false
 - name: xarray-spatial
-  version: 0.10.1
+  version: 0.10.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -26406,14 +26179,14 @@ package:
     urllib3: ''
     xarray: ''
     zstandard: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.2-pyhd8ed1ab_0.conda
   hash:
-    md5: bcbb516ee86e84254906cc1aeb4b0216
-    sha256: edf92d5609f2d5cc6ba510cc3584fdf55002c1f5c855b36bbd9a5e736a711163
+    md5: 235b842dd45d73f515394e640db614c5
+    sha256: df65d6a808619ca3b45aedeade36d6743a548db2979a64c5bf97734e7e9854ce
   category: main
   optional: false
 - name: xarray-spatial
-  version: 0.10.1
+  version: 0.10.2
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -26426,10 +26199,10 @@ package:
     urllib3: ''
     xarray: ''
     zstandard: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.2-pyhd8ed1ab_0.conda
   hash:
-    md5: bcbb516ee86e84254906cc1aeb4b0216
-    sha256: edf92d5609f2d5cc6ba510cc3584fdf55002c1f5c855b36bbd9a5e736a711163
+    md5: 235b842dd45d73f515394e640db614c5
+    sha256: df65d6a808619ca3b45aedeade36d6743a548db2979a64c5bf97734e7e9854ce
   category: main
   optional: false
 - name: xarray_leaflet

--- a/pytorch-notebook/packages.txt
+++ b/pytorch-notebook/packages.txt
@@ -12,7 +12,7 @@ aiohttp==3.13.5
 aioitertools==0.13.0
 aiosignal==1.4.0
 alembic==1.18.4
-alsa-lib==1.2.15.3
+alsa-lib==1.2.16
 amqp==5.3.1
 annotated-doc==0.0.4
 annotated-types==0.7.0
@@ -54,7 +54,7 @@ aws-c-sdkutils==0.2.4
 aws-checksums==0.2.10
 aws-crt-cpp==0.38.3
 aws-sdk-cpp==1.11.747
-awscli==2.34.58
+awscli==2.34.60
 awscrt==0.32.2
 azure-core==1.41.0
 azure-core-cpp==1.16.2
@@ -150,7 +150,7 @@ dataclasses==0.8
 datashader==0.19.1
 dav1d==1.2.1
 dbus==1.16.2
-debugpy==1.8.20
+debugpy==1.8.21
 decorator==5.3.1
 defusedxml==0.7.1
 deprecated==1.3.1
@@ -180,7 +180,7 @@ esmpy==8.9.1
 exceptiongroup==1.3.1
 executing==2.2.1
 fastapi==0.136.3
-fastapi-cli==0.0.23
+fastapi-cli==0.0.24
 fastapi-core==0.136.3
 fastar==0.11.0
 fastcore==1.13.2
@@ -200,7 +200,7 @@ font-ttf-dejavu-sans-mono==2.37
 font-ttf-inconsolata==3.000
 font-ttf-source-code-pro==2.038
 font-ttf-ubuntu==0.83
-fontconfig==2.18.0
+fontconfig==2.18.1
 fonts-conda-ecosystem==1
 fonts-conda-forge==1
 fonttools==4.63.0
@@ -242,7 +242,7 @@ google-api-core==2.30.3
 google-auth==2.53.0
 google-auth-oauthlib==1.4.0
 google-cloud-core==2.5.1
-google-cloud-sdk==570.0.0
+google-cloud-sdk==571.0.0
 google-cloud-storage==3.10.1
 google-cloud-storage-control==1.10.0
 google-crc32c==1.8.0
@@ -250,7 +250,7 @@ google-resumable-media==2.8.0
 googleapis-common-protos==1.75.0
 googleapis-common-protos-grpc==1.75.0
 gpytorch==1.15.2
-graphite2==1.3.14
+graphite2==1.3.15
 graphviz==14.1.2
 greenlet==3.5.1
 grpc-google-iam-v1==0.14.4
@@ -267,7 +267,7 @@ h3==4.4.1
 h3-py==4.4.1
 h5netcdf==1.8.1
 h5py==3.16.0
-harfbuzz==14.2.0
+harfbuzz==14.2.1
 hdf4==4.2.15
 hdf5==2.1.0
 heapdict==1.0.1
@@ -406,8 +406,6 @@ libegl-devel==1.7.0
 libev==4.33
 libevent==2.1.12
 libexpat==2.8.1
-libfabric==2.5.1
-libfabric1==2.5.1
 libffi==3.5.2
 libfido2==1.17.0
 libflac==1.5.0
@@ -472,11 +470,10 @@ libopus==1.6.1
 libparquet==23.0.1
 libpciaccess==0.19
 libplacebo==7.360.1
-libpnetcdf==1.14.1
 libpng==1.6.58
 libprotobuf==6.33.5
 libre2-11==2025.11.05
-librsvg==2.62.2
+librsvg==2.62.3
 librttopo==1.1.0
 libsecret==0.21.7
 libsndfile==1.2.2
@@ -516,12 +513,12 @@ libzlib==1.3.2
 libzopfli==1.0.3
 lightly==1.15.22
 lightly-utils==0.0.2
-lightning==2.6.1
+lightning==2.6.5
 lightning-utilities==0.15.3
 line_profiler==5.0.2
 linear_operator==0.6.1
 linkify-it-py==2.1.0
-llvm-openmp==22.1.6
+llvm-openmp==22.1.7
 llvmlite==0.47.0
 locket==1.0.0
 lonboard==0.16.0
@@ -549,8 +546,6 @@ morecantile==7.0.3
 mpc==1.4.0
 mpfr==4.2.2
 mpg123==1.32.9
-mpi==1.0.1
-mpich==5.0.1
 mpmath==1.3.0
 msal==1.37.0
 msal_extensions==1.3.1
@@ -617,7 +612,6 @@ panel-material-ui==0.11.2
 pangeo-dask==2026.01.21
 pangeo-notebook==2026.01.21
 pango==1.56.4
-parallelio==2.6.9
 param==2.4.0
 parso==0.8.7
 partd==1.4.2
@@ -754,7 +748,7 @@ s3transfer==0.17.1
 safetensors==0.7.0
 satpy==0.60.0
 scikit-image==0.26.0
-scikit-learn==1.8.0
+scikit-learn==1.9.0
 scipy==1.17.1
 sdl2==2.32.56
 sdl3==3.4.10
@@ -808,20 +802,19 @@ torchmetrics==1.9.0
 torchvision==0.26.0
 tornado==6.5.6
 tqdm==4.67.3
-traitlets==5.15.0
+traitlets==5.15.1
 traittypes==0.2.3
 triton==3.6.0
 trollimage==1.28.0
-trollsift==1.0.0
+trollsift==1.0.1
 typer==0.25.1
-typeshed-client==2.11.0
+typeshed-client==2.12.0
 typing-extensions==4.15.0
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 typing_utils==0.1.0
 tzdata==2025c
 uc-micro-py==2.0.0
-ucx==1.20.1
 ujson==5.12.1
 uncompresspy==0.4.1
 unicodedata2==17.0.1
@@ -855,7 +848,7 @@ wrapt==2.2.1
 x264==1%21164.3095
 x265==3.5
 xarray==2026.4.0
-xarray-spatial==0.10.1
+xarray-spatial==0.10.2
 xarray_leaflet==0.2.3
 xarrayutils==2.0.1
 xbatcher==0.4.0


### PR DESCRIPTION
Following suggestion at https://github.com/pangeo-data/pangeo-docker-images/pull/643#issuecomment-4609457253 to keep ml-notebook/tensorflow on Python 3.12 while making it possible to upgrade the other docker images to Python 3.13.