### PR TITLE
Use ubuntu-24.04-arm for WatchCondaForge workflow

### DIFF
--- a/.github/workflows/WatchCondaForge.yml
+++ b/.github/workflows/WatchCondaForge.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   check-version:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04-arm
     if: github.repository == 'pangeo-data/pangeo-docker-images'
 
     steps:


### PR DESCRIPTION
Getting `failed to connect to the docker API at unix:///var/run/docker.sock` on ubuntu-slim runners that doesn't have docker (e.g. [this job](https://github.com/pangeo-data/pangeo-docker-images/actions/runs/26923157867)), xref https://github.com/actions/runner-images/issues/13583

Patches #649.