### PR TITLE
Document extending notebook images with packages

### DIFF
--- a/docs/howto/custom-image.md
+++ b/docs/howto/custom-image.md
@@ -1,3 +1,37 @@
 # Build a custom image
 
 Advanced users may want a highly customized environment that still works on Pangeo BinderHubs. You can do that by building off the pangeo `base-image` following our [template repository example](https://github.com/pangeo-data/pangeo-binder-template). Further documentation on the configuration files in the `binder` subfolder can be found in the [repo2docker documentation](https://repo2docker.readthedocs.io/en/latest/config_files.html#configuration-files).
+
+## Add packages to a notebook image
+
+If you only need to add a small number of packages, you can build a thin image on top of an existing Pangeo notebook image such as `pangeo/pangeo-notebook` instead of starting from `base-image`.
+
+Pangeo notebook images install user-facing Python packages into the `notebook` conda environment. The environment is also exposed as the `CONDA_ENV` environment variable, so Dockerfiles can target it without hard-coding the name.
+
+```dockerfile
+FROM pangeo/pangeo-notebook:latest
+
+# Install conda packages into the existing notebook environment.
+RUN mamba install --yes --name ${CONDA_ENV} \
+    package_a \
+    package_b \
+    && mamba clean --all --force --yes
+
+# Install pip packages into the same environment.
+RUN /srv/conda/envs/${CONDA_ENV}/bin/python -m pip install --no-cache-dir package_c
+```
+
+For larger changes, keep package declarations in files and copy them into the image:
+
+```dockerfile
+FROM pangeo/pangeo-notebook:latest
+
+COPY environment.yml /tmp/environment.yml
+COPY requirements.txt /tmp/requirements.txt
+
+RUN mamba env update --name ${CONDA_ENV} --file /tmp/environment.yml \
+    && mamba clean --all --force --yes
+RUN /srv/conda/envs/${CONDA_ENV}/bin/python -m pip install --no-cache-dir -r /tmp/requirements.txt
+```
+
+When possible, prefer conda-forge packages installed with `mamba` and use `pip` only for packages that are not available from conda-forge. Pin the parent Pangeo image tag and important package versions for reproducible images.


### PR DESCRIPTION
Fixes #500.

Adds a concrete section to the custom image guide for the common case where users only need to add a few packages on top of an existing notebook image, rather than starting from `base-image`.

The examples target the existing `${CONDA_ENV}` / `notebook` environment and show both:

- direct `mamba install --name ${CONDA_ENV}` plus pip through the environment Python
- file-based `environment.yml` / `requirements.txt` installs

Verification:

```console
$ python3 - <<'PY'
from pathlib import Path
s = Path('docs/howto/custom-image.md').read_text()
assert 'mamba install --yes --name ${CONDA_ENV}' in s
assert '/srv/conda/envs/${CONDA_ENV}/bin/python -m pip install' in s
assert 'mamba env update --name ${CONDA_ENV}' in s
print('custom-image docs include conda and pip examples for notebook images')
PY
custom-image docs include conda and pip examples for notebook images
```
